### PR TITLE
Add npm publish metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,24 @@
     "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'",
     "typecheck": "tsc --noEmit"
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "mcp",
+    "pentest",
+    "attack-graph",
+    "nmap",
+    "ffuf",
+    "nuclei",
+    "security"
+  ],
+  "author": "0x6d61",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/0x6d61/sonobat.git"
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "better-sqlite3": "^12.6.2",


### PR DESCRIPTION
## Summary

- `author`: `0x6d61` を設定
- `repository`: GitHub URL を追加
- `engines`: `node >= 20` を追加
- `keywords`: `mcp`, `pentest`, `security` 等を追加

## Test plan

- [x] `npm run build` 成功
- [x] `npm pack --dry-run` で公開内容確認（5ファイル、48.6 kB）
- [x] 全201テスト通過

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)