### PR TITLE
Fix proposer parameter_discovery bug and add value_fuzz action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonobat",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AttackDataGraph for autonomous penetration testing",
   "type": "module",
   "main": "dist/index.js",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -21,7 +21,7 @@ import { registerResources } from './resources.js';
 export function createMcpServer(db: Database.Database): McpServer {
   const server = new McpServer({
     name: 'sonobat',
-    version: '0.1.0',
+    version: '0.1.1',
   });
 
   // Register tools

--- a/src/types/engine.ts
+++ b/src/types/engine.ts
@@ -35,6 +35,7 @@ export interface Action {
     | 'nuclei_scan'
     | 'parameter_discovery'
     | 'value_collection'
+    | 'value_fuzz'
     | 'vhost_discovery';
   /** 人間向けの説明 */
   description: string;


### PR DESCRIPTION
## Summary

- **Bug fix**: `parameter_discovery` がサービス単位で input をチェックしていたバグを修正。`endpoint_inputs` テーブル経由でエンドポイント単位でチェックするように変更
- **New action**: `value_fuzz` アクションを追加。input + observation があるが vulnerability が未検出のエンドポイントに対してファジングを提案
- Version bump to 0.1.1

## Test plan

- [x] 204 テスト全パス（201 → 204、+3 新規テスト）
- [x] `npm run build` 成功
- [x] 既存テストも endpoint_input を追加して正しいデータモデルに修正

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)