### PR TITLE
Add GitHub Actions CI and fix type/lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run format:check
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,30 @@
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  {
+    files: ['src/**/*.ts', 'tests/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs['recommended'].rules,
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-require-imports': 'error',
+    },
+  },
+  {
+    ignores: ['dist/', 'node_modules/', '*.js', '*.mjs', '*.cjs'],
+  },
+];

--- a/src/parser/nuclei-parser.ts
+++ b/src/parser/nuclei-parser.ts
@@ -272,8 +272,8 @@ function processFinding(
       const cve: ParsedCve = {
         vulnerabilityTitle: info.name,
         cveId,
-        cvssScore: classification['cvss-score'],
-        cvssVector: classification['cvss-metrics'],
+        cvssScore: typeof classification['cvss-score'] === 'number' ? classification['cvss-score'] : undefined,
+        cvssVector: typeof classification['cvss-metrics'] === 'string' ? classification['cvss-metrics'] : undefined,
       };
       result.cves.push(cve);
     }

--- a/tests/db/migrate.test.ts
+++ b/tests/db/migrate.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
 import crypto from 'node:crypto';
 import { migrateDatabase } from '../../src/db/migrate.js';
-import { SCHEMA_SQL } from '../../src/db/schema.js';
 
 // ---------------------------------------------------------------------------
 // ヘルパー

--- a/tests/db/repository/endpoint-input-repository.test.ts
+++ b/tests/db/repository/endpoint-input-repository.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
-import crypto from 'node:crypto';
 import { migrateDatabase } from '../../../src/db/migrate.js';
 import { EndpointInputRepository } from '../../../src/db/repository/endpoint-input-repository.js';
 import { HostRepository } from '../../../src/db/repository/host-repository.js';

--- a/tests/db/repository/service-observation-repository.test.ts
+++ b/tests/db/repository/service-observation-repository.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
-import crypto from 'node:crypto';
 import { migrateDatabase } from '../../../src/db/migrate.js';
 import { HostRepository } from '../../../src/db/repository/host-repository.js';
 import { ArtifactRepository } from '../../../src/db/repository/artifact-repository.js';

--- a/tests/db/repository/service-repository.test.ts
+++ b/tests/db/repository/service-repository.test.ts
@@ -7,8 +7,6 @@ import { ArtifactRepository } from '../../../src/db/repository/artifact-reposito
 import { ServiceRepository } from '../../../src/db/repository/service-repository.js';
 import type { Host, Artifact, Service } from '../../../src/types/entities.js';
 import type {
-  CreateHostInput,
-  CreateArtifactInput,
   CreateServiceInput,
   UpdateServiceInput,
 } from '../../../src/types/repository.js';

--- a/tests/engine/ingest.test.ts
+++ b/tests/engine/ingest.test.ts
@@ -4,10 +4,7 @@ import crypto from 'node:crypto';
 import { migrateDatabase } from '../../src/db/migrate.js';
 import { ingestContent } from '../../src/engine/ingest.js';
 import { HostRepository } from '../../src/db/repository/host-repository.js';
-import { ServiceRepository } from '../../src/db/repository/service-repository.js';
 import { ArtifactRepository } from '../../src/db/repository/artifact-repository.js';
-import { HttpEndpointRepository } from '../../src/db/repository/http-endpoint-repository.js';
-import { VulnerabilityRepository } from '../../src/db/repository/vulnerability-repository.js';
 
 // ---------------------------------------------------------------------------
 // テストデータ

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -14,12 +14,8 @@ import { createMcpServer } from '../../src/mcp/server.js';
 import { HostRepository } from '../../src/db/repository/host-repository.js';
 import { ArtifactRepository } from '../../src/db/repository/artifact-repository.js';
 import { ServiceRepository } from '../../src/db/repository/service-repository.js';
-import { HttpEndpointRepository } from '../../src/db/repository/http-endpoint-repository.js';
 import { VulnerabilityRepository } from '../../src/db/repository/vulnerability-repository.js';
 import { CredentialRepository } from '../../src/db/repository/credential-repository.js';
-import { InputRepository } from '../../src/db/repository/input-repository.js';
-import { ObservationRepository } from '../../src/db/repository/observation-repository.js';
-import { VhostRepository } from '../../src/db/repository/vhost-repository.js';
 
 function now(): string {
   return new Date().toISOString();

--- a/tests/parser/ffuf-parser.test.ts
+++ b/tests/parser/ffuf-parser.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { parseFfufJson } from '../../src/parser/ffuf-parser.js';
 
 // ---------------------------------------------------------------------------

--- a/tests/parser/nmap-parser.test.ts
+++ b/tests/parser/nmap-parser.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeAll } from 'vitest';
 import { parseNmapXml } from '../../src/parser/nmap-parser.js';
 import type { ParseResult } from '../../src/types/parser.js';
 

--- a/tests/parser/nuclei-parser.test.ts
+++ b/tests/parser/nuclei-parser.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeAll } from 'vitest';
 import { parseNucleiJsonl } from '../../src/parser/nuclei-parser.js';
 import type { ParseResult } from '../../src/types/parser.js';
 


### PR DESCRIPTION
## Summary

- ESLint flat config (`eslint.config.mjs`) を追加（@typescript-eslint/recommended ルール）
- GitHub Actions CI ワークフロー追加（format:check → lint → typecheck → test → build）
- 既存の型エラー修正（nuclei-parser.ts の cvssScore/cvssVector 型ナローイング）
- テストファイルの vitest インポート追加、未使用インポート削除

## Test plan

- [x] `npm run lint` — エラーなし
- [x] `npm run typecheck` — エラーなし
- [x] `npm test` — 204 テスト全パス
- [x] `npm run build` — 成功

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)