### PR TITLE
Fix CI: Prettier formatting and cross-platform glob patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src/ tests/",
     "lint:fix": "eslint src/ tests/ --fix",
-    "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
-    "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'",
+    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/src/db/repository/endpoint-input-repository.ts
+++ b/src/db/repository/endpoint-input-repository.ts
@@ -43,20 +43,12 @@ export class EndpointInputRepository {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
-    const stmt = this.db.prepare<
-      [string, string, string, string, string]
-    >(
+    const stmt = this.db.prepare<[string, string, string, string, string]>(
       `INSERT INTO endpoint_inputs (id, endpoint_id, input_id, evidence_artifact_id, created_at)
        VALUES (?, ?, ?, ?, ?)`,
     );
 
-    stmt.run(
-      id,
-      input.endpointId,
-      input.inputId,
-      input.evidenceArtifactId,
-      now,
-    );
+    stmt.run(id, input.endpointId, input.inputId, input.evidenceArtifactId, now);
 
     return {
       id,

--- a/src/db/repository/host-repository.ts
+++ b/src/db/repository/host-repository.ts
@@ -45,21 +45,12 @@ export class HostRepository {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
-    const stmt = this.db.prepare<
-      [string, string, string, string, string, string]
-    >(
+    const stmt = this.db.prepare<[string, string, string, string, string, string]>(
       `INSERT INTO hosts (id, authority_kind, authority, resolved_ips_json, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?)`,
     );
 
-    stmt.run(
-      id,
-      input.authorityKind,
-      input.authority,
-      input.resolvedIpsJson,
-      now,
-      now,
-    );
+    stmt.run(id, input.authorityKind, input.authority, input.resolvedIpsJson, now, now);
 
     return {
       id,

--- a/src/db/repository/http-endpoint-repository.ts
+++ b/src/db/repository/http-endpoint-repository.ts
@@ -119,9 +119,7 @@ export class HttpEndpointRepository {
 
   /** Delete an HttpEndpoint by id. Returns true if a row was deleted. */
   delete(id: string): boolean {
-    const stmt = this.db.prepare<[string]>(
-      'DELETE FROM http_endpoints WHERE id = ?',
-    );
+    const stmt = this.db.prepare<[string]>('DELETE FROM http_endpoints WHERE id = ?');
     const result = stmt.run(id);
     return result.changes > 0;
   }

--- a/src/db/repository/input-repository.ts
+++ b/src/db/repository/input-repository.ts
@@ -47,22 +47,12 @@ export class InputRepository {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
-    const stmt = this.db.prepare<
-      [string, string, string, string, string | null, string, string]
-    >(
+    const stmt = this.db.prepare<[string, string, string, string, string | null, string, string]>(
       `INSERT INTO inputs (id, service_id, location, name, type_hint, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
     );
 
-    stmt.run(
-      id,
-      input.serviceId,
-      input.location,
-      input.name,
-      input.typeHint ?? null,
-      now,
-      now,
-    );
+    stmt.run(id, input.serviceId, input.location, input.name, input.typeHint ?? null, now, now);
 
     return {
       id,

--- a/src/db/repository/scan-repository.ts
+++ b/src/db/repository/scan-repository.ts
@@ -41,7 +41,9 @@ export class ScanRepository {
       'INSERT INTO scans (id, started_at, finished_at, notes) VALUES (?, ?, ?, ?)',
     );
 
-    this.selectByIdStmt = this.db.prepare('SELECT id, started_at, finished_at, notes FROM scans WHERE id = ?');
+    this.selectByIdStmt = this.db.prepare(
+      'SELECT id, started_at, finished_at, notes FROM scans WHERE id = ?',
+    );
 
     this.selectAllStmt = this.db.prepare('SELECT id, started_at, finished_at, notes FROM scans');
   }
@@ -50,12 +52,7 @@ export class ScanRepository {
   create(input: CreateScanInput): Scan {
     const id = crypto.randomUUID();
 
-    this.insertStmt.run(
-      id,
-      input.startedAt,
-      input.finishedAt ?? null,
-      input.notes ?? null,
-    );
+    this.insertStmt.run(id, input.startedAt, input.finishedAt ?? null, input.notes ?? null);
 
     return {
       id,

--- a/src/db/repository/service-observation-repository.ts
+++ b/src/db/repository/service-observation-repository.ts
@@ -47,9 +47,7 @@ export class ServiceObservationRepository {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
-    const stmt = this.db.prepare<
-      [string, string, string, string, string, string, string]
-    >(
+    const stmt = this.db.prepare<[string, string, string, string, string, string, string]>(
       `INSERT INTO service_observations (id, service_id, key, value, confidence, evidence_artifact_id, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
     );

--- a/src/db/repository/service-repository.ts
+++ b/src/db/repository/service-repository.ts
@@ -60,7 +60,21 @@ export class ServiceRepository {
     const now = new Date().toISOString();
 
     const stmt = this.db.prepare<
-      [string, string, string, number, string, string, string | null, string | null, string | null, string, string, string, string]
+      [
+        string,
+        string,
+        string,
+        number,
+        string,
+        string,
+        string | null,
+        string | null,
+        string | null,
+        string,
+        string,
+        string,
+        string,
+      ]
     >(
       `INSERT INTO services (id, host_id, transport, port, app_proto, proto_confidence, banner, product, version, state, evidence_artifact_id, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/src/db/repository/vhost-repository.ts
+++ b/src/db/repository/vhost-repository.ts
@@ -45,21 +45,12 @@ export class VhostRepository {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
-    const stmt = this.db.prepare<
-      [string, string, string, string | null, string, string]
-    >(
+    const stmt = this.db.prepare<[string, string, string, string | null, string, string]>(
       `INSERT INTO vhosts (id, host_id, hostname, source, evidence_artifact_id, created_at)
        VALUES (?, ?, ?, ?, ?, ?)`,
     );
 
-    stmt.run(
-      id,
-      input.hostId,
-      input.hostname,
-      input.source ?? null,
-      input.evidenceArtifactId,
-      now,
-    );
+    stmt.run(id, input.hostId, input.hostname, input.source ?? null, input.evidenceArtifactId, now);
 
     return {
       id,

--- a/src/engine/datalog/evaluator.ts
+++ b/src/engine/datalog/evaluator.ts
@@ -10,10 +10,7 @@
  * Supports positive literals, negated literals, and comparison operators.
  */
 
-import {
-  DatalogResourceError,
-  DEFAULT_EVAL_CONFIG,
-} from './types.js';
+import { DatalogResourceError, DEFAULT_EVAL_CONFIG } from './types.js';
 import type {
   Program,
   Rule,
@@ -86,9 +83,7 @@ class FactDB {
 
 /** Serialize a tuple into a unique string key for deduplication. */
 function serializeTuple(tuple: Tuple): string {
-  return tuple
-    .map((v) => (typeof v === 'number' ? `n:${v}` : `s:${v}`))
-    .join('\0');
+  return tuple.map((v) => (typeof v === 'number' ? `n:${v}` : `s:${v}`)).join('\0');
 }
 
 // ============================================================
@@ -160,16 +155,12 @@ export function evaluate(
       // Check timeout
       const elapsed = performance.now() - startTime;
       if (elapsed > cfg.timeoutMs) {
-        throw new DatalogResourceError(
-          `Evaluation timeout: exceeded ${cfg.timeoutMs}ms`,
-        );
+        throw new DatalogResourceError(`Evaluation timeout: exceeded ${cfg.timeoutMs}ms`);
       }
 
       // Check iteration limit
       if (stats.iterations >= cfg.maxIterations) {
-        throw new DatalogResourceError(
-          `Iteration limit exceeded: ${cfg.maxIterations}`,
-        );
+        throw new DatalogResourceError(`Iteration limit exceeded: ${cfg.maxIterations}`);
       }
 
       changed = false;
@@ -180,9 +171,7 @@ export function evaluate(
         for (const tuple of derivedTuples) {
           // Check tuple limit
           if (db.size >= cfg.maxTuples) {
-            throw new DatalogResourceError(
-              `Tuple limit exceeded: ${cfg.maxTuples}`,
-            );
+            throw new DatalogResourceError(`Tuple limit exceeded: ${cfg.maxTuples}`);
           }
           const isNew = db.add(rule.head.predicate, tuple);
           if (isNew) {
@@ -197,9 +186,7 @@ export function evaluate(
   stats.elapsedMs = performance.now() - startTime;
 
   // Evaluate queries
-  const answers: QueryAnswer[] = program.queries.map((q) =>
-    evaluateQuery(q.atom, db),
-  );
+  const answers: QueryAnswer[] = program.queries.map((q) => evaluateQuery(q.atom, db));
 
   return { answers, stats };
 }
@@ -239,12 +226,7 @@ function evaluateRule(rule: Rule, db: FactDB): Tuple[] {
  * @param db - Fact database
  * @returns Array of complete bindings satisfying all literals
  */
-function evaluateBody(
-  body: BodyLiteral[],
-  index: number,
-  binding: Binding,
-  db: FactDB,
-): Binding[] {
+function evaluateBody(body: BodyLiteral[], index: number, binding: Binding, db: FactDB): Binding[] {
   // Base case: all literals satisfied
   if (index >= body.length) {
     return [binding];
@@ -305,11 +287,7 @@ function evaluateBody(
  * extending the given binding. Returns a new binding on success,
  * or null if unification fails.
  */
-function unifyAtom(
-  atom: Atom,
-  factTuple: Tuple,
-  binding: Binding,
-): Binding | null {
+function unifyAtom(atom: Atom, factTuple: Tuple, binding: Binding): Binding | null {
   // Arity mismatch
   if (atom.args.length !== factTuple.length) {
     return null;
@@ -336,11 +314,7 @@ function unifyAtom(
  * Unify a single term against a concrete value.
  * Returns updated binding on success, null on failure.
  */
-function unifyTerm(
-  term: Term,
-  value: string | number,
-  binding: Binding,
-): Binding | null {
+function unifyTerm(term: Term, value: string | number, binding: Binding): Binding | null {
   if (term.kind === 'constant') {
     // Constant must match exactly
     return term.value === value ? binding : null;
@@ -368,12 +342,7 @@ function unifyTerm(
  * Returns false if any term is unbound (which shouldn't happen
  * in safe Datalog, but we handle it defensively).
  */
-function evaluateComparison(
-  op: ComparisonOp,
-  left: Term,
-  right: Term,
-  binding: Binding,
-): boolean {
+function evaluateComparison(op: ComparisonOp, left: Term, right: Term, binding: Binding): boolean {
   const leftVal = resolveTerm(left, binding);
   const rightVal = resolveTerm(right, binding);
 
@@ -401,10 +370,7 @@ function evaluateComparison(
  * Resolve a term to its concrete value using the current binding.
  * Returns null if a variable is unbound.
  */
-function resolveTerm(
-  term: Term,
-  binding: Binding,
-): string | number | null {
+function resolveTerm(term: Term, binding: Binding): string | number | null {
   if (term.kind === 'constant') {
     return term.value;
   }

--- a/src/engine/datalog/fact-extractor.ts
+++ b/src/engine/datalog/fact-extractor.ts
@@ -94,12 +94,14 @@ interface VhostRow {
 type ExtractorFn = (db: Database.Database, limit?: number) => Fact[];
 
 function extractHosts(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT id, authority, authority_kind FROM hosts LIMIT ?'
-    : 'SELECT id, authority, authority_kind FROM hosts';
-  const rows = limit !== undefined
-    ? db.prepare<[number], HostRow>(sql).all(limit)
-    : db.prepare<[], HostRow>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT id, authority, authority_kind FROM hosts LIMIT ?'
+      : 'SELECT id, authority, authority_kind FROM hosts';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], HostRow>(sql).all(limit)
+      : db.prepare<[], HostRow>(sql).all();
   return rows.map((r) => ({
     predicate: 'host',
     values: [r.id, r.authority, r.authority_kind],
@@ -107,12 +109,14 @@ function extractHosts(db: Database.Database, limit?: number): Fact[] {
 }
 
 function extractServices(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT host_id, id, transport, port, app_proto, state FROM services LIMIT ?'
-    : 'SELECT host_id, id, transport, port, app_proto, state FROM services';
-  const rows = limit !== undefined
-    ? db.prepare<[number], ServiceRow>(sql).all(limit)
-    : db.prepare<[], ServiceRow>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT host_id, id, transport, port, app_proto, state FROM services LIMIT ?'
+      : 'SELECT host_id, id, transport, port, app_proto, state FROM services';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], ServiceRow>(sql).all(limit)
+      : db.prepare<[], ServiceRow>(sql).all();
   return rows.map((r) => ({
     predicate: 'service',
     values: [r.host_id, r.id, r.transport, r.port, r.app_proto, r.state],
@@ -120,12 +124,14 @@ function extractServices(db: Database.Database, limit?: number): Fact[] {
 }
 
 function extractHttpEndpoints(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT service_id, id, method, path, status_code FROM http_endpoints LIMIT ?'
-    : 'SELECT service_id, id, method, path, status_code FROM http_endpoints';
-  const rows = limit !== undefined
-    ? db.prepare<[number], HttpEndpointRow>(sql).all(limit)
-    : db.prepare<[], HttpEndpointRow>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT service_id, id, method, path, status_code FROM http_endpoints LIMIT ?'
+      : 'SELECT service_id, id, method, path, status_code FROM http_endpoints';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], HttpEndpointRow>(sql).all(limit)
+      : db.prepare<[], HttpEndpointRow>(sql).all();
   return rows.map((r) => ({
     predicate: 'http_endpoint',
     values: [r.service_id, r.id, r.method, r.path, r.status_code ?? 0],
@@ -133,12 +139,14 @@ function extractHttpEndpoints(db: Database.Database, limit?: number): Fact[] {
 }
 
 function extractInputs(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT service_id, id, location, name FROM inputs LIMIT ?'
-    : 'SELECT service_id, id, location, name FROM inputs';
-  const rows = limit !== undefined
-    ? db.prepare<[number], InputRow>(sql).all(limit)
-    : db.prepare<[], InputRow>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT service_id, id, location, name FROM inputs LIMIT ?'
+      : 'SELECT service_id, id, location, name FROM inputs';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], InputRow>(sql).all(limit)
+      : db.prepare<[], InputRow>(sql).all();
   return rows.map((r) => ({
     predicate: 'input',
     values: [r.service_id, r.id, r.location, r.name],
@@ -146,12 +154,14 @@ function extractInputs(db: Database.Database, limit?: number): Fact[] {
 }
 
 function extractEndpointInputs(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT endpoint_id, input_id FROM endpoint_inputs LIMIT ?'
-    : 'SELECT endpoint_id, input_id FROM endpoint_inputs';
-  const rows = limit !== undefined
-    ? db.prepare<[number], EndpointInputRow>(sql).all(limit)
-    : db.prepare<[], EndpointInputRow>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT endpoint_id, input_id FROM endpoint_inputs LIMIT ?'
+      : 'SELECT endpoint_id, input_id FROM endpoint_inputs';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], EndpointInputRow>(sql).all(limit)
+      : db.prepare<[], EndpointInputRow>(sql).all();
   return rows.map((r) => ({
     predicate: 'endpoint_input',
     values: [r.endpoint_id, r.input_id],
@@ -159,12 +169,14 @@ function extractEndpointInputs(db: Database.Database, limit?: number): Fact[] {
 }
 
 function extractObservations(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT input_id, id, raw_value, source, confidence FROM observations LIMIT ?'
-    : 'SELECT input_id, id, raw_value, source, confidence FROM observations';
-  const rows = limit !== undefined
-    ? db.prepare<[number], ObservationRow>(sql).all(limit)
-    : db.prepare<[], ObservationRow>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT input_id, id, raw_value, source, confidence FROM observations LIMIT ?'
+      : 'SELECT input_id, id, raw_value, source, confidence FROM observations';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], ObservationRow>(sql).all(limit)
+      : db.prepare<[], ObservationRow>(sql).all();
   return rows.map((r) => ({
     predicate: 'observation',
     values: [r.input_id, r.id, r.raw_value, r.source, r.confidence],
@@ -172,12 +184,14 @@ function extractObservations(db: Database.Database, limit?: number): Fact[] {
 }
 
 function extractCredentials(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT service_id, id, username, secret_type, source, confidence FROM credentials LIMIT ?'
-    : 'SELECT service_id, id, username, secret_type, source, confidence FROM credentials';
-  const rows = limit !== undefined
-    ? db.prepare<[number], CredentialRow>(sql).all(limit)
-    : db.prepare<[], CredentialRow>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT service_id, id, username, secret_type, source, confidence FROM credentials LIMIT ?'
+      : 'SELECT service_id, id, username, secret_type, source, confidence FROM credentials';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], CredentialRow>(sql).all(limit)
+      : db.prepare<[], CredentialRow>(sql).all();
   return rows.map((r) => ({
     predicate: 'credential',
     values: [r.service_id, r.id, r.username, r.secret_type, r.source, r.confidence],
@@ -185,12 +199,14 @@ function extractCredentials(db: Database.Database, limit?: number): Fact[] {
 }
 
 function extractVulnerabilities(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT service_id, id, vuln_type, title, severity, confidence, endpoint_id FROM vulnerabilities LIMIT ?'
-    : 'SELECT service_id, id, vuln_type, title, severity, confidence, endpoint_id FROM vulnerabilities';
-  const rows = limit !== undefined
-    ? db.prepare<[number], VulnerabilityRow>(sql).all(limit)
-    : db.prepare<[], VulnerabilityRow>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT service_id, id, vuln_type, title, severity, confidence, endpoint_id FROM vulnerabilities LIMIT ?'
+      : 'SELECT service_id, id, vuln_type, title, severity, confidence, endpoint_id FROM vulnerabilities';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], VulnerabilityRow>(sql).all(limit)
+      : db.prepare<[], VulnerabilityRow>(sql).all();
 
   const facts: Fact[] = [];
   for (const r of rows) {
@@ -203,12 +219,14 @@ function extractVulnerabilities(db: Database.Database, limit?: number): Fact[] {
 }
 
 function extractVulnerabilityEndpoints(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT id, endpoint_id FROM vulnerabilities WHERE endpoint_id IS NOT NULL LIMIT ?'
-    : 'SELECT id, endpoint_id FROM vulnerabilities WHERE endpoint_id IS NOT NULL';
-  const rows = limit !== undefined
-    ? db.prepare<[number], { id: string; endpoint_id: string }>(sql).all(limit)
-    : db.prepare<[], { id: string; endpoint_id: string }>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT id, endpoint_id FROM vulnerabilities WHERE endpoint_id IS NOT NULL LIMIT ?'
+      : 'SELECT id, endpoint_id FROM vulnerabilities WHERE endpoint_id IS NOT NULL';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], { id: string; endpoint_id: string }>(sql).all(limit)
+      : db.prepare<[], { id: string; endpoint_id: string }>(sql).all();
   return rows.map((r) => ({
     predicate: 'vulnerability_endpoint',
     values: [r.id, r.endpoint_id],
@@ -216,12 +234,14 @@ function extractVulnerabilityEndpoints(db: Database.Database, limit?: number): F
 }
 
 function extractCves(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT vulnerability_id, cve_id, cvss_score FROM cves LIMIT ?'
-    : 'SELECT vulnerability_id, cve_id, cvss_score FROM cves';
-  const rows = limit !== undefined
-    ? db.prepare<[number], CveRow>(sql).all(limit)
-    : db.prepare<[], CveRow>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT vulnerability_id, cve_id, cvss_score FROM cves LIMIT ?'
+      : 'SELECT vulnerability_id, cve_id, cvss_score FROM cves';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], CveRow>(sql).all(limit)
+      : db.prepare<[], CveRow>(sql).all();
   return rows.map((r) => ({
     predicate: 'cve',
     values: [r.vulnerability_id, r.cve_id, r.cvss_score ?? 0],
@@ -229,12 +249,14 @@ function extractCves(db: Database.Database, limit?: number): Fact[] {
 }
 
 function extractVhosts(db: Database.Database, limit?: number): Fact[] {
-  const sql = limit !== undefined
-    ? 'SELECT host_id, id, hostname, source FROM vhosts LIMIT ?'
-    : 'SELECT host_id, id, hostname, source FROM vhosts';
-  const rows = limit !== undefined
-    ? db.prepare<[number], VhostRow>(sql).all(limit)
-    : db.prepare<[], VhostRow>(sql).all();
+  const sql =
+    limit !== undefined
+      ? 'SELECT host_id, id, hostname, source FROM vhosts LIMIT ?'
+      : 'SELECT host_id, id, hostname, source FROM vhosts';
+  const rows =
+    limit !== undefined
+      ? db.prepare<[number], VhostRow>(sql).all(limit)
+      : db.prepare<[], VhostRow>(sql).all();
   return rows.map((r) => ({
     predicate: 'vhost',
     values: [r.host_id, r.id, r.hostname, r.source ?? ''],

--- a/src/engine/datalog/index.ts
+++ b/src/engine/datalog/index.ts
@@ -21,11 +21,7 @@ export type { PresetRule };
 /**
  * List facts from the database, optionally filtered by predicate.
  */
-export function listFacts(
-  db: Database.Database,
-  predicate?: string,
-  limit?: number,
-): Fact[] {
+export function listFacts(db: Database.Database, predicate?: string, limit?: number): Fact[] {
   if (predicate !== undefined) {
     return extractFactsByPredicate(db, predicate, limit);
   }

--- a/src/engine/datalog/parser.ts
+++ b/src/engine/datalog/parser.ts
@@ -19,10 +19,7 @@
  */
 
 import { tokenize } from './tokenizer.js';
-import {
-  DatalogSyntaxError,
-  DatalogSafetyError,
-} from './types.js';
+import { DatalogSyntaxError, DatalogSafetyError } from './types.js';
 import type {
   Token,
   TokenKind,
@@ -36,14 +33,7 @@ import type {
 } from './types.js';
 
 /** Comparison operator token kinds */
-const COMPARISON_OPS: ReadonlySet<TokenKind> = new Set([
-  'EQ',
-  'NEQ',
-  'LT',
-  'GT',
-  'LTE',
-  'GTE',
-]);
+const COMPARISON_OPS: ReadonlySet<TokenKind> = new Set(['EQ', 'NEQ', 'LT', 'GT', 'LTE', 'GTE']);
 
 /** Map from token kind to ComparisonOp string */
 const TOKEN_TO_COMP_OP: Readonly<Record<string, ComparisonOp>> = {

--- a/src/engine/datalog/preset-rules.ts
+++ b/src/engine/datalog/preset-rules.ts
@@ -39,7 +39,8 @@ const PRESET_RULES: readonly PresetRule[] = [
   },
   {
     name: 'exploitable_endpoints',
-    description: 'HTTP endpoints with known vulnerabilities, including vulnerability type and severity.',
+    description:
+      'HTTP endpoints with known vulnerabilities, including vulnerability type and severity.',
     ruleText: [
       'exploitable(Host, Port, Path, VulnType, Severity) :- service(Host, Svc, _, Port, _, _), http_endpoint(Svc, Ep, _, Path, _), vulnerability_endpoint(Vuln, Ep), vulnerability(Svc, Vuln, VulnType, _, Severity, _).',
       '?- exploitable(Host, Port, Path, VulnType, Severity).',
@@ -55,7 +56,8 @@ const PRESET_RULES: readonly PresetRule[] = [
   },
   {
     name: 'attack_surface',
-    description: 'Full attack surface overview combining host, port, endpoint path, input name, and input location.',
+    description:
+      'Full attack surface overview combining host, port, endpoint path, input name, and input location.',
     ruleText: [
       'surface(Host, Port, Path, InputName, Location) :- service(Host, Svc, _, Port, _, "open"), http_endpoint(Svc, Ep, _, Path, _), endpoint_input(Ep, Inp), input(Svc, Inp, Location, InputName).',
       '?- surface(Host, Port, Path, InputName, Location).',
@@ -63,7 +65,8 @@ const PRESET_RULES: readonly PresetRule[] = [
   },
   {
     name: 'unfuzzed_inputs',
-    description: 'Inputs with observations but no associated vulnerability endpoint — candidates for fuzzing.',
+    description:
+      'Inputs with observations but no associated vulnerability endpoint — candidates for fuzzing.',
     ruleText: [
       'unfuzzed(Host, Port, Path, InputName) :- service(Host, Svc, _, Port, _, "open"), http_endpoint(Svc, Ep, _, Path, _), endpoint_input(Ep, Inp), input(Svc, Inp, _, InputName), observation(Inp, _, _, _, _), not vulnerability_endpoint(_, Ep).',
       '?- unfuzzed(Host, Port, Path, InputName).',

--- a/src/engine/datalog/tokenizer.ts
+++ b/src/engine/datalog/tokenizer.ts
@@ -88,7 +88,13 @@ export function tokenize(source: string): Token[] {
         col++;
       }
       // Decimal part
-      if (pos < source.length && source[pos] === '.' && pos + 1 < source.length && source[pos + 1] >= '0' && source[pos + 1] <= '9') {
+      if (
+        pos < source.length &&
+        source[pos] === '.' &&
+        pos + 1 < source.length &&
+        source[pos + 1] >= '0' &&
+        source[pos + 1] <= '9'
+      ) {
         value += '.';
         pos++;
         col++;
@@ -148,10 +154,30 @@ export function tokenize(source: string): Token[] {
     // Single/multi-character symbols
     const startCol = col;
 
-    if (ch === '(') { tokens.push({ kind: 'LPAREN', value: '(', line, col: startCol }); pos++; col++; continue; }
-    if (ch === ')') { tokens.push({ kind: 'RPAREN', value: ')', line, col: startCol }); pos++; col++; continue; }
-    if (ch === ',') { tokens.push({ kind: 'COMMA', value: ',', line, col: startCol }); pos++; col++; continue; }
-    if (ch === '.') { tokens.push({ kind: 'DOT', value: '.', line, col: startCol }); pos++; col++; continue; }
+    if (ch === '(') {
+      tokens.push({ kind: 'LPAREN', value: '(', line, col: startCol });
+      pos++;
+      col++;
+      continue;
+    }
+    if (ch === ')') {
+      tokens.push({ kind: 'RPAREN', value: ')', line, col: startCol });
+      pos++;
+      col++;
+      continue;
+    }
+    if (ch === ',') {
+      tokens.push({ kind: 'COMMA', value: ',', line, col: startCol });
+      pos++;
+      col++;
+      continue;
+    }
+    if (ch === '.') {
+      tokens.push({ kind: 'DOT', value: '.', line, col: startCol });
+      pos++;
+      col++;
+      continue;
+    }
 
     // :- (COLON_DASH)
     if (ch === ':' && pos + 1 < source.length && source[pos + 1] === '-') {
@@ -188,9 +214,24 @@ export function tokenize(source: string): Token[] {
       col += 2;
       continue;
     }
-    if (ch === '<') { tokens.push({ kind: 'LT', value: '<', line, col: startCol }); pos++; col++; continue; }
-    if (ch === '>') { tokens.push({ kind: 'GT', value: '>', line, col: startCol }); pos++; col++; continue; }
-    if (ch === '=') { tokens.push({ kind: 'EQ', value: '=', line, col: startCol }); pos++; col++; continue; }
+    if (ch === '<') {
+      tokens.push({ kind: 'LT', value: '<', line, col: startCol });
+      pos++;
+      col++;
+      continue;
+    }
+    if (ch === '>') {
+      tokens.push({ kind: 'GT', value: '>', line, col: startCol });
+      pos++;
+      col++;
+      continue;
+    }
+    if (ch === '=') {
+      tokens.push({ kind: 'EQ', value: '=', line, col: startCol });
+      pos++;
+      col++;
+      continue;
+    }
 
     throw new DatalogSyntaxError(`Unexpected character '${ch}'`, line, col);
   }
@@ -204,5 +245,7 @@ function isIdentStart(ch: string): boolean {
 }
 
 function isIdentPart(ch: string): boolean {
-  return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch === '_';
+  return (
+    (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch === '_'
+  );
 }

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -22,18 +22,23 @@ export function registerResources(server: McpServer, db: Database.Database): voi
   const vulnRepo = new VulnerabilityRepository(db);
 
   // 1. sonobat://hosts — Host list
-  server.resource('hosts', 'sonobat://hosts', { description: 'List of all discovered hosts' }, async () => {
-    const hosts = hostRepo.findAll();
-    return {
-      contents: [
-        {
-          uri: 'sonobat://hosts',
-          mimeType: 'application/json',
-          text: JSON.stringify(hosts, null, 2),
-        },
-      ],
-    };
-  });
+  server.resource(
+    'hosts',
+    'sonobat://hosts',
+    { description: 'List of all discovered hosts' },
+    async () => {
+      const hosts = hostRepo.findAll();
+      return {
+        contents: [
+          {
+            uri: 'sonobat://hosts',
+            mimeType: 'application/json',
+            text: JSON.stringify(hosts, null, 2),
+          },
+        ],
+      };
+    },
+  );
 
   // 2. sonobat://hosts/{id} — Host detail tree
   server.resource(

--- a/src/mcp/tools/datalog.ts
+++ b/src/mcp/tools/datalog.ts
@@ -8,7 +8,12 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type Database from 'better-sqlite3';
 import { z } from 'zod';
-import { listFacts, runDatalog, queryAttackPaths, listPatterns } from '../../engine/datalog/index.js';
+import {
+  listFacts,
+  runDatalog,
+  queryAttackPaths,
+  listPatterns,
+} from '../../engine/datalog/index.js';
 import type { Fact, EvalResult } from '../../engine/datalog/types.js';
 
 /**
@@ -17,9 +22,7 @@ import type { Fact, EvalResult } from '../../engine/datalog/types.js';
  * Example: host("abc-123", "10.0.0.1", "IP").
  */
 function formatFact(fact: Fact): string {
-  const args = fact.values
-    .map((v) => (typeof v === 'number' ? String(v) : `"${v}"`))
-    .join(', ');
+  const args = fact.values.map((v) => (typeof v === 'number' ? String(v) : `"${v}"`)).join(', ');
   return `${fact.predicate}(${args}).`;
 }
 
@@ -48,10 +51,7 @@ function formatEvalResult(result: EvalResult): string {
 
     // Calculate column widths
     const widths = columns.map((col, i) =>
-      Math.max(
-        col.length,
-        ...answer.tuples.map((t) => String(t[i]).length),
-      ),
+      Math.max(col.length, ...answer.tuples.map((t) => String(t[i]).length)),
     );
 
     // Header row
@@ -59,11 +59,7 @@ function formatEvalResult(result: EvalResult): string {
 
     // Data rows
     const dataRows = answer.tuples.map(
-      (tuple) =>
-        '  ' +
-        tuple
-          .map((val, i) => String(val).padEnd(widths[i]))
-          .join(' | '),
+      (tuple) => '  ' + tuple.map((val, i) => String(val).padEnd(widths[i])).join(' | '),
     );
 
     sections.push(
@@ -113,11 +109,11 @@ export function registerDatalogTools(server: McpServer, db: Database.Database): 
     'Execute a custom Datalog program against the AttackDataGraph. Supports rules with :- and queries with ?-. Optionally save the program as a named rule for future reuse.',
     {
       program: z.string().describe('Datalog program text (rules and queries)'),
-      save_name: z.string().optional().describe('Save the program as a named rule for future reuse'),
-      save_description: z
+      save_name: z
         .string()
         .optional()
-        .describe('Description of the saved rule'),
+        .describe('Save the program as a named rule for future reuse'),
+      save_description: z.string().optional().describe('Description of the saved rule'),
       generated_by: z
         .string()
         .optional()
@@ -125,8 +121,7 @@ export function registerDatalogTools(server: McpServer, db: Database.Database): 
     },
     async ({ program, save_name, save_description, generated_by }) => {
       try {
-        const generatedBy =
-          generated_by === 'human' ? 'human' : 'ai';
+        const generatedBy = generated_by === 'human' ? 'human' : 'ai';
         const result = runDatalog(db, program, {
           saveName: save_name,
           saveDescription: save_description,

--- a/src/mcp/tools/mutation.ts
+++ b/src/mcp/tools/mutation.ts
@@ -46,7 +46,9 @@ export function registerMutationTools(server: McpServer, db: Database.Database):
       const existing = hostRepo.findByAuthority(authority);
       if (existing) {
         return {
-          content: [{ type: 'text', text: `Host already exists: ${JSON.stringify(existing, null, 2)}` }],
+          content: [
+            { type: 'text', text: `Host already exists: ${JSON.stringify(existing, null, 2)}` },
+          ],
         };
       }
       const host = hostRepo.create({
@@ -67,7 +69,9 @@ export function registerMutationTools(server: McpServer, db: Database.Database):
       username: z.string().describe('Username'),
       secret: z.string().describe('Secret value (password, token, etc.)'),
       secretType: z.enum(['password', 'token', 'api_key', 'ssh_key']).describe('Type of secret'),
-      source: z.enum(['brute_force', 'default', 'leaked', 'manual']).describe('How the credential was obtained'),
+      source: z
+        .enum(['brute_force', 'default', 'leaked', 'manual'])
+        .describe('How the credential was obtained'),
       confidence: z.enum(['high', 'medium', 'low']).describe('Confidence level').default('medium'),
     },
     async ({ serviceId, username, secret, secretType, source, confidence }) => {

--- a/src/mcp/tools/propose.ts
+++ b/src/mcp/tools/propose.ts
@@ -20,7 +20,9 @@ export function registerProposeTool(server: McpServer, db: Database.Database): v
       const actions = propose(db, hostId);
       if (actions.length === 0) {
         return {
-          content: [{ type: 'text', text: 'No actions proposed. All discovered data appears complete.' }],
+          content: [
+            { type: 'text', text: 'No actions proposed. All discovered data appears complete.' },
+          ],
         };
       }
       return { content: [{ type: 'text', text: JSON.stringify(actions, null, 2) }] };

--- a/src/mcp/tools/query.ts
+++ b/src/mcp/tools/query.ts
@@ -77,7 +77,10 @@ export function registerQueryTools(server: McpServer, db: Database.Database): vo
     'List all input parameters for a service, optionally filtered by location',
     {
       serviceId: z.string().describe('Service UUID'),
-      location: z.string().optional().describe('Filter by location (query, path, body, header, cookie)'),
+      location: z
+        .string()
+        .optional()
+        .describe('Filter by location (query, path, body, header, cookie)'),
     },
     async ({ serviceId, location }) => {
       const inputs = inputRepo.findByServiceId(serviceId, location);
@@ -117,7 +120,10 @@ export function registerQueryTools(server: McpServer, db: Database.Database): vo
     'List vulnerabilities, optionally filtered by service and/or severity',
     {
       serviceId: z.string().optional().describe('Service UUID (optional, omit to list all)'),
-      severity: z.string().optional().describe('Filter by severity (critical, high, medium, low, info)'),
+      severity: z
+        .string()
+        .optional()
+        .describe('Filter by severity (critical, high, medium, low, info)'),
     },
     async ({ serviceId, severity }) => {
       const vulns = serviceId

--- a/src/parser/nmap-parser.ts
+++ b/src/parser/nmap-parser.ts
@@ -194,8 +194,7 @@ function processPort(port: NmapPort, hostAuthority: string): ParsedService {
   const serviceName = service?.['@_name'] ?? '';
 
   // appProto の決定: https or tunnel=ssl -> 'https'
-  const appProto =
-    service !== undefined && isHttps(service) ? 'https' : serviceName;
+  const appProto = service !== undefined && isHttps(service) ? 'https' : serviceName;
 
   const banner = service !== undefined ? buildBanner(service) : undefined;
   const protoConfidence = toProtoConfidence(service?.['@_conf']);

--- a/src/parser/nuclei-parser.ts
+++ b/src/parser/nuclei-parser.ts
@@ -53,14 +53,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isStringArray(value: unknown): value is string[] {
-  return (
-    Array.isArray(value) && value.every((item) => typeof item === 'string')
-  );
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
 }
 
-function isNucleiClassification(
-  value: unknown,
-): value is NucleiClassification {
+function isNucleiClassification(value: unknown): value is NucleiClassification {
   if (!isRecord(value)) return false;
   // classification は空オブジェクトでも許容する
   if ('cve-id' in value && !isStringArray(value['cve-id'])) return false;
@@ -272,8 +268,14 @@ function processFinding(
       const cve: ParsedCve = {
         vulnerabilityTitle: info.name,
         cveId,
-        cvssScore: typeof classification['cvss-score'] === 'number' ? classification['cvss-score'] : undefined,
-        cvssVector: typeof classification['cvss-metrics'] === 'string' ? classification['cvss-metrics'] : undefined,
+        cvssScore:
+          typeof classification['cvss-score'] === 'number'
+            ? classification['cvss-score']
+            : undefined,
+        cvssVector:
+          typeof classification['cvss-metrics'] === 'string'
+            ? classification['cvss-metrics']
+            : undefined,
       };
       result.cves.push(cve);
     }

--- a/tests/db/migrate.test.ts
+++ b/tests/db/migrate.test.ts
@@ -55,7 +55,10 @@ interface InsertedArtifact {
   artifactId: string;
 }
 
-function insertArtifact(db: InstanceType<typeof Database>, scanId: string | null = null): InsertedArtifact {
+function insertArtifact(
+  db: InstanceType<typeof Database>,
+  scanId: string | null = null,
+): InsertedArtifact {
   const artifactId = uuid();
   db.prepare(
     `INSERT INTO artifacts (id, scan_id, tool, kind, path, captured_at)

--- a/tests/db/repository/artifact-repository.test.ts
+++ b/tests/db/repository/artifact-repository.test.ts
@@ -41,9 +41,7 @@ describe('ArtifactRepository', () => {
     const artifact: Artifact = repo.create(input);
 
     expect(artifact.id).toBeDefined();
-    expect(artifact.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(artifact.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(artifact.tool).toBe(input.tool);
     expect(artifact.kind).toBe(input.kind);
     expect(artifact.path).toBe(input.path);

--- a/tests/db/repository/credential-repository.test.ts
+++ b/tests/db/repository/credential-repository.test.ts
@@ -90,9 +90,7 @@ describe('CredentialRepository', () => {
     const credential: Credential = repo.create(input);
 
     expect(credential.id).toBeDefined();
-    expect(credential.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(credential.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(credential.serviceId).toBe(serviceId);
     expect(credential.endpointId).toBeUndefined();
     expect(credential.username).toBe('admin');

--- a/tests/db/repository/cve-repository.test.ts
+++ b/tests/db/repository/cve-repository.test.ts
@@ -86,21 +86,13 @@ describe('CveRepository', () => {
     const cve: Cve = repo.create(input);
 
     expect(cve.id).toBeDefined();
-    expect(cve.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(cve.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(cve.vulnerabilityId).toBe(vulnerabilityId);
     expect(cve.cveId).toBe('CVE-2024-12345');
-    expect(cve.description).toBe(
-      'Critical SQL injection vulnerability in login form',
-    );
+    expect(cve.description).toBe('Critical SQL injection vulnerability in login form');
     expect(cve.cvssScore).toBe(9.8);
-    expect(cve.cvssVector).toBe(
-      'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H',
-    );
-    expect(cve.referenceUrl).toBe(
-      'https://nvd.nist.gov/vuln/detail/CVE-2024-12345',
-    );
+    expect(cve.cvssVector).toBe('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
+    expect(cve.referenceUrl).toBe('https://nvd.nist.gov/vuln/detail/CVE-2024-12345');
     expect(cve.createdAt).toBeDefined();
   });
 

--- a/tests/db/repository/datalog-rule-repository.test.ts
+++ b/tests/db/repository/datalog-rule-repository.test.ts
@@ -69,7 +69,11 @@ describe('DatalogRuleRepository', () => {
   });
 
   it('delete — ルールを削除できる', () => {
-    const rule = repo.create({ name: 'to_delete', ruleText: 'a(X) :- b(X).', generatedBy: 'human' });
+    const rule = repo.create({
+      name: 'to_delete',
+      ruleText: 'a(X) :- b(X).',
+      generatedBy: 'human',
+    });
 
     expect(repo.delete(rule.id)).toBe(true);
     expect(repo.findById(rule.id)).toBeUndefined();

--- a/tests/db/repository/host-repository.test.ts
+++ b/tests/db/repository/host-repository.test.ts
@@ -43,9 +43,7 @@ describe('HostRepository', () => {
     const host: Host = repo.create(input);
 
     expect(host.id).toBeDefined();
-    expect(host.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(host.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(host.authorityKind).toBe(input.authorityKind);
     expect(host.authority).toBe(input.authority);
     expect(host.resolvedIpsJson).toBe(input.resolvedIpsJson);

--- a/tests/db/repository/http-endpoint-repository.test.ts
+++ b/tests/db/repository/http-endpoint-repository.test.ts
@@ -76,9 +76,7 @@ describe('HttpEndpointRepository', () => {
     const endpoint: HttpEndpoint = repo.create(input);
 
     expect(endpoint.id).toBeDefined();
-    expect(endpoint.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(endpoint.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(endpoint.serviceId).toBe(serviceId);
     expect(endpoint.vhostId).toBeUndefined();
     expect(endpoint.baseUri).toBe('http://10.0.0.1:80');

--- a/tests/db/repository/input-repository.test.ts
+++ b/tests/db/repository/input-repository.test.ts
@@ -81,9 +81,7 @@ describe('InputRepository', () => {
     const created: Input = repo.create(input);
 
     expect(created.id).toBeDefined();
-    expect(created.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(created.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(created.serviceId).toBe(serviceId);
     expect(created.location).toBe('query');
     expect(created.name).toBe('id');

--- a/tests/db/repository/scan-repository.test.ts
+++ b/tests/db/repository/scan-repository.test.ts
@@ -39,9 +39,7 @@ describe('ScanRepository', () => {
     const scan: Scan = repo.create(input);
 
     expect(scan.id).toBeDefined();
-    expect(scan.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(scan.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(scan.startedAt).toBe(input.startedAt);
     expect(scan.finishedAt).toBe(input.finishedAt);
     expect(scan.notes).toBe(input.notes);

--- a/tests/db/repository/service-observation-repository.test.ts
+++ b/tests/db/repository/service-observation-repository.test.ts
@@ -5,12 +5,7 @@ import { HostRepository } from '../../../src/db/repository/host-repository.js';
 import { ArtifactRepository } from '../../../src/db/repository/artifact-repository.js';
 import { ServiceRepository } from '../../../src/db/repository/service-repository.js';
 import { ServiceObservationRepository } from '../../../src/db/repository/service-observation-repository.js';
-import type {
-  Host,
-  Artifact,
-  Service,
-  ServiceObservation,
-} from '../../../src/types/entities.js';
+import type { Host, Artifact, Service, ServiceObservation } from '../../../src/types/entities.js';
 import type { CreateServiceObservationInput } from '../../../src/types/repository.js';
 
 // ---------------------------------------------------------------------------

--- a/tests/db/repository/service-repository.test.ts
+++ b/tests/db/repository/service-repository.test.ts
@@ -6,10 +6,7 @@ import { HostRepository } from '../../../src/db/repository/host-repository.js';
 import { ArtifactRepository } from '../../../src/db/repository/artifact-repository.js';
 import { ServiceRepository } from '../../../src/db/repository/service-repository.js';
 import type { Host, Artifact, Service } from '../../../src/types/entities.js';
-import type {
-  CreateServiceInput,
-  UpdateServiceInput,
-} from '../../../src/types/repository.js';
+import type { CreateServiceInput, UpdateServiceInput } from '../../../src/types/repository.js';
 
 // ---------------------------------------------------------------------------
 // ヘルパー
@@ -74,9 +71,7 @@ describe('ServiceRepository', () => {
     const service: Service = repo.create(input);
 
     expect(service.id).toBeDefined();
-    expect(service.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(service.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(service.hostId).toBe(host.id);
     expect(service.transport).toBe('tcp');
     expect(service.port).toBe(80);

--- a/tests/db/repository/vhost-repository.test.ts
+++ b/tests/db/repository/vhost-repository.test.ts
@@ -55,9 +55,7 @@ describe('VhostRepository', () => {
     const vhost: Vhost = repo.create(input);
 
     expect(vhost.id).toBeDefined();
-    expect(vhost.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(vhost.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(vhost.hostId).toBe(host.id);
     expect(vhost.hostname).toBe('example.com');
     expect(vhost.source).toBe('nmap');

--- a/tests/db/repository/vulnerability-repository.test.ts
+++ b/tests/db/repository/vulnerability-repository.test.ts
@@ -77,9 +77,7 @@ describe('VulnerabilityRepository', () => {
     const vuln: Vulnerability = repo.create(input);
 
     expect(vuln.id).toBeDefined();
-    expect(vuln.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(vuln.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     expect(vuln.serviceId).toBe(serviceId);
     expect(vuln.vulnType).toBe('sqli');
     expect(vuln.title).toBe('SQL Injection');

--- a/tests/engine/datalog/evaluator.test.ts
+++ b/tests/engine/datalog/evaluator.test.ts
@@ -50,9 +50,7 @@ describe('Evaluator', () => {
     });
 
     it('baseFacts とソース中のファクトの両方を統合する', () => {
-      const facts: Fact[] = [
-        { predicate: 'parent', values: ['alice', 'bob'] },
-      ];
+      const facts: Fact[] = [{ predicate: 'parent', values: ['alice', 'bob'] }];
       const source = `
         parent("bob", "carol").
         ?- parent(X, Y).
@@ -294,9 +292,7 @@ describe('Evaluator', () => {
         ?- a(X).
       `;
       const facts: Fact[] = [{ predicate: 'd', values: ['x'] }];
-      expect(() => evalDatalog(source, facts, { maxRules: 2 })).toThrow(
-        DatalogResourceError,
-      );
+      expect(() => evalDatalog(source, facts, { maxRules: 2 })).toThrow(DatalogResourceError);
     });
 
     it('maxIterations を超えた場合に DatalogResourceError をスローする', () => {
@@ -312,9 +308,7 @@ describe('Evaluator', () => {
         ?- reach(X, Y).
       `;
       // maxIterations = 1 は不十分なので失敗する
-      expect(() => evalDatalog(source, facts, { maxIterations: 1 })).toThrow(
-        DatalogResourceError,
-      );
+      expect(() => evalDatalog(source, facts, { maxIterations: 1 })).toThrow(DatalogResourceError);
     });
 
     it('maxTuples を超えた場合に DatalogResourceError をスローする', () => {
@@ -328,9 +322,7 @@ describe('Evaluator', () => {
         ?- reach(X, Y).
       `;
       // maxTuples = 10 は不十分なので失敗する
-      expect(() => evalDatalog(source, facts, { maxTuples: 10 })).toThrow(
-        DatalogResourceError,
-      );
+      expect(() => evalDatalog(source, facts, { maxTuples: 10 })).toThrow(DatalogResourceError);
     });
   });
 
@@ -404,9 +396,7 @@ describe('Evaluator', () => {
   describe('columns の検証', () => {
     it('クエリ内の変数名が columns として返される', () => {
       const source = `?- parent(X, Y).`;
-      const facts: Fact[] = [
-        { predicate: 'parent', values: ['alice', 'bob'] },
-      ];
+      const facts: Fact[] = [{ predicate: 'parent', values: ['alice', 'bob'] }];
       const result = evalDatalog(source, facts);
 
       expect(result.answers[0].columns).toEqual(['X', 'Y']);
@@ -414,9 +404,7 @@ describe('Evaluator', () => {
 
     it('定数を含むクエリでは変数のみが columns に含まれる', () => {
       const source = `?- parent(X, "bob").`;
-      const facts: Fact[] = [
-        { predicate: 'parent', values: ['alice', 'bob'] },
-      ];
+      const facts: Fact[] = [{ predicate: 'parent', values: ['alice', 'bob'] }];
       const result = evalDatalog(source, facts);
 
       expect(result.answers[0].columns).toEqual(['X']);
@@ -424,9 +412,7 @@ describe('Evaluator', () => {
 
     it('変数がないクエリでは columns は空', () => {
       const source = `?- parent("alice", "bob").`;
-      const facts: Fact[] = [
-        { predicate: 'parent', values: ['alice', 'bob'] },
-      ];
+      const facts: Fact[] = [{ predicate: 'parent', values: ['alice', 'bob'] }];
       const result = evalDatalog(source, facts);
 
       expect(result.answers[0].columns).toEqual([]);

--- a/tests/engine/datalog/index.test.ts
+++ b/tests/engine/datalog/index.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { migrateDatabase } from '../../../src/db/migrate.js';
-import { listFacts, runDatalog, queryAttackPaths, listPatterns } from '../../../src/engine/datalog/index.js';
+import {
+  listFacts,
+  runDatalog,
+  queryAttackPaths,
+  listPatterns,
+} from '../../../src/engine/datalog/index.js';
 import { HostRepository } from '../../../src/db/repository/host-repository.js';
 import { ArtifactRepository } from '../../../src/db/repository/artifact-repository.js';
 import { ServiceRepository } from '../../../src/db/repository/service-repository.js';
@@ -84,11 +89,25 @@ describe('Datalog public API', () => {
       const artifactRepo = new ArtifactRepository(db);
       const serviceRepo = new ServiceRepository(db);
 
-      const host = hostRepo.create({ authorityKind: 'IP', authority: '10.0.0.1', resolvedIpsJson: '[]' });
-      const artifact = artifactRepo.create({ tool: 'nmap', kind: 'tool_output', path: '/tmp/scan.xml', capturedAt: now() });
+      const host = hostRepo.create({
+        authorityKind: 'IP',
+        authority: '10.0.0.1',
+        resolvedIpsJson: '[]',
+      });
+      const artifact = artifactRepo.create({
+        tool: 'nmap',
+        kind: 'tool_output',
+        path: '/tmp/scan.xml',
+        capturedAt: now(),
+      });
       serviceRepo.create({
-        hostId: host.id, transport: 'tcp', port: 80, appProto: 'http',
-        protoConfidence: 'high', state: 'open', evidenceArtifactId: artifact.id,
+        hostId: host.id,
+        transport: 'tcp',
+        port: 80,
+        appProto: 'http',
+        protoConfidence: 'high',
+        state: 'open',
+        evidenceArtifactId: artifact.id,
       });
 
       const result = queryAttackPaths(db, 'reachable_services');

--- a/tests/engine/datalog/preset-rules.test.ts
+++ b/tests/engine/datalog/preset-rules.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  getPresetRules,
-  getPresetRule,
-} from '../../../src/engine/datalog/preset-rules.js';
+import { getPresetRules, getPresetRule } from '../../../src/engine/datalog/preset-rules.js';
 import { parse } from '../../../src/engine/datalog/parser.js';
 
 describe('preset-rules', () => {

--- a/tests/engine/datalog/tokenizer.test.ts
+++ b/tests/engine/datalog/tokenizer.test.ts
@@ -77,10 +77,25 @@ describe('Tokenizer', () => {
   it('完全なルールをトークナイズ', () => {
     const tokens = tokenize('parent(X, Y) :- person(X), child_of(Y, X).');
     const expected = [
-      'IDENT', 'LPAREN', 'VARIABLE', 'COMMA', 'VARIABLE', 'RPAREN',
+      'IDENT',
+      'LPAREN',
+      'VARIABLE',
+      'COMMA',
+      'VARIABLE',
+      'RPAREN',
       'COLON_DASH',
-      'IDENT', 'LPAREN', 'VARIABLE', 'RPAREN', 'COMMA',
-      'IDENT', 'LPAREN', 'VARIABLE', 'COMMA', 'VARIABLE', 'RPAREN', 'DOT',
+      'IDENT',
+      'LPAREN',
+      'VARIABLE',
+      'RPAREN',
+      'COMMA',
+      'IDENT',
+      'LPAREN',
+      'VARIABLE',
+      'COMMA',
+      'VARIABLE',
+      'RPAREN',
+      'DOT',
     ];
     expect(kinds(tokens)).toEqual(expected);
   });
@@ -88,7 +103,14 @@ describe('Tokenizer', () => {
   it('クエリをトークナイズ', () => {
     const tokens = tokenize('?- parent(X, "Alice").');
     expect(kinds(tokens)).toEqual([
-      'QUERY', 'IDENT', 'LPAREN', 'VARIABLE', 'COMMA', 'STRING', 'RPAREN', 'DOT',
+      'QUERY',
+      'IDENT',
+      'LPAREN',
+      'VARIABLE',
+      'COMMA',
+      'STRING',
+      'RPAREN',
+      'DOT',
     ]);
   });
 

--- a/tests/engine/normalizer.test.ts
+++ b/tests/engine/normalizer.test.ts
@@ -69,9 +69,7 @@ describe('normalize', () => {
   it('nmap 結果を正規化する（hosts + services + serviceObservations）', () => {
     const parseResult: ParseResult = {
       ...emptyParseResult(),
-      hosts: [
-        { authority: '10.0.0.1', authorityKind: 'IP' },
-      ],
+      hosts: [{ authority: '10.0.0.1', authorityKind: 'IP' }],
       services: [
         {
           hostAuthority: '10.0.0.1',
@@ -144,9 +142,7 @@ describe('normalize', () => {
   it('ffuf 結果を正規化する（endpoints + inputs + observations + endpointInputs）', () => {
     const parseResult: ParseResult = {
       ...emptyParseResult(),
-      hosts: [
-        { authority: '10.0.0.1', authorityKind: 'IP' },
-      ],
+      hosts: [{ authority: '10.0.0.1', authorityKind: 'IP' }],
       services: [
         {
           hostAuthority: '10.0.0.1',
@@ -274,9 +270,7 @@ describe('normalize', () => {
   it('nuclei 結果を正規化する（vulnerabilities + cves）', () => {
     const parseResult: ParseResult = {
       ...emptyParseResult(),
-      hosts: [
-        { authority: '10.0.0.1', authorityKind: 'IP' },
-      ],
+      hosts: [{ authority: '10.0.0.1', authorityKind: 'IP' }],
       services: [
         {
           hostAuthority: '10.0.0.1',
@@ -359,9 +353,7 @@ describe('normalize', () => {
     // 1 回目: host 10.0.0.1 + service tcp/80
     const firstParseResult: ParseResult = {
       ...emptyParseResult(),
-      hosts: [
-        { authority: '10.0.0.1', authorityKind: 'IP' },
-      ],
+      hosts: [{ authority: '10.0.0.1', authorityKind: 'IP' }],
       services: [
         {
           hostAuthority: '10.0.0.1',
@@ -389,9 +381,7 @@ describe('normalize', () => {
     // 2 回目: 同じ host 10.0.0.1 + 新しい service tcp/443
     const secondParseResult: ParseResult = {
       ...emptyParseResult(),
-      hosts: [
-        { authority: '10.0.0.1', authorityKind: 'IP' },
-      ],
+      hosts: [{ authority: '10.0.0.1', authorityKind: 'IP' }],
       services: [
         {
           hostAuthority: '10.0.0.1',
@@ -429,9 +419,7 @@ describe('normalize', () => {
     // 1 回目: host 10.0.0.1 + service tcp/80
     const firstParseResult: ParseResult = {
       ...emptyParseResult(),
-      hosts: [
-        { authority: '10.0.0.1', authorityKind: 'IP' },
-      ],
+      hosts: [{ authority: '10.0.0.1', authorityKind: 'IP' }],
       services: [
         {
           hostAuthority: '10.0.0.1',
@@ -459,9 +447,7 @@ describe('normalize', () => {
     // 2 回目: まったく同じ host + service
     const secondParseResult: ParseResult = {
       ...emptyParseResult(),
-      hosts: [
-        { authority: '10.0.0.1', authorityKind: 'IP' },
-      ],
+      hosts: [{ authority: '10.0.0.1', authorityKind: 'IP' }],
       services: [
         {
           hostAuthority: '10.0.0.1',
@@ -496,9 +482,7 @@ describe('normalize', () => {
     // 1 回目: host + service + input (query, 'q') + observation
     const firstParseResult: ParseResult = {
       ...emptyParseResult(),
-      hosts: [
-        { authority: '10.0.0.1', authorityKind: 'IP' },
-      ],
+      hosts: [{ authority: '10.0.0.1', authorityKind: 'IP' }],
       services: [
         {
           hostAuthority: '10.0.0.1',
@@ -546,9 +530,7 @@ describe('normalize', () => {
     // 2 回目: 同じ input (query, 'q') + 新しい observation
     const secondParseResult: ParseResult = {
       ...emptyParseResult(),
-      hosts: [
-        { authority: '10.0.0.1', authorityKind: 'IP' },
-      ],
+      hosts: [{ authority: '10.0.0.1', authorityKind: 'IP' }],
       services: [
         {
           hostAuthority: '10.0.0.1',
@@ -629,9 +611,7 @@ describe('normalize', () => {
     // 正常な ParseResult で normalize を実行し、全データがコミットされることを検証
     const parseResult: ParseResult = {
       ...emptyParseResult(),
-      hosts: [
-        { authority: '10.0.0.1', authorityKind: 'IP' },
-      ],
+      hosts: [{ authority: '10.0.0.1', authorityKind: 'IP' }],
       services: [
         {
           hostAuthority: '10.0.0.1',

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -104,11 +104,25 @@ describe('MCP Server', () => {
     const artifactRepo = new ArtifactRepository(db);
     const serviceRepo = new ServiceRepository(db);
 
-    const host = hostRepo.create({ authorityKind: 'IP', authority: '10.0.0.1', resolvedIpsJson: '[]' });
-    const artifact = artifactRepo.create({ tool: 'nmap', kind: 'tool_output', path: '/tmp/scan.xml', capturedAt: now() });
+    const host = hostRepo.create({
+      authorityKind: 'IP',
+      authority: '10.0.0.1',
+      resolvedIpsJson: '[]',
+    });
+    const artifact = artifactRepo.create({
+      tool: 'nmap',
+      kind: 'tool_output',
+      path: '/tmp/scan.xml',
+      capturedAt: now(),
+    });
     serviceRepo.create({
-      hostId: host.id, transport: 'tcp', port: 80, appProto: 'http',
-      protoConfidence: 'high', state: 'open', evidenceArtifactId: artifact.id,
+      hostId: host.id,
+      transport: 'tcp',
+      port: 80,
+      appProto: 'http',
+      protoConfidence: 'high',
+      state: 'open',
+      evidenceArtifactId: artifact.id,
     });
 
     const result = await client.callTool({ name: 'get_host', arguments: { hostId: host.id } });
@@ -131,15 +145,34 @@ describe('MCP Server', () => {
     const artifactRepo = new ArtifactRepository(db);
     const serviceRepo = new ServiceRepository(db);
 
-    const host = hostRepo.create({ authorityKind: 'IP', authority: '10.0.0.1', resolvedIpsJson: '[]' });
-    const artifact = artifactRepo.create({ tool: 'nmap', kind: 'tool_output', path: '/tmp/scan.xml', capturedAt: now() });
-    serviceRepo.create({
-      hostId: host.id, transport: 'tcp', port: 80, appProto: 'http',
-      protoConfidence: 'high', state: 'open', evidenceArtifactId: artifact.id,
+    const host = hostRepo.create({
+      authorityKind: 'IP',
+      authority: '10.0.0.1',
+      resolvedIpsJson: '[]',
+    });
+    const artifact = artifactRepo.create({
+      tool: 'nmap',
+      kind: 'tool_output',
+      path: '/tmp/scan.xml',
+      capturedAt: now(),
     });
     serviceRepo.create({
-      hostId: host.id, transport: 'tcp', port: 443, appProto: 'https',
-      protoConfidence: 'high', state: 'open', evidenceArtifactId: artifact.id,
+      hostId: host.id,
+      transport: 'tcp',
+      port: 80,
+      appProto: 'http',
+      protoConfidence: 'high',
+      state: 'open',
+      evidenceArtifactId: artifact.id,
+    });
+    serviceRepo.create({
+      hostId: host.id,
+      transport: 'tcp',
+      port: 443,
+      appProto: 'https',
+      protoConfidence: 'high',
+      state: 'open',
+      evidenceArtifactId: artifact.id,
     });
 
     const result = await client.callTool({ name: 'list_services', arguments: { hostId: host.id } });
@@ -154,15 +187,33 @@ describe('MCP Server', () => {
     const serviceRepo = new ServiceRepository(db);
     const credentialRepo = new CredentialRepository(db);
 
-    const host = hostRepo.create({ authorityKind: 'IP', authority: '10.0.0.1', resolvedIpsJson: '[]' });
-    const artifact = artifactRepo.create({ tool: 'nmap', kind: 'tool_output', path: '/tmp/scan.xml', capturedAt: now() });
+    const host = hostRepo.create({
+      authorityKind: 'IP',
+      authority: '10.0.0.1',
+      resolvedIpsJson: '[]',
+    });
+    const artifact = artifactRepo.create({
+      tool: 'nmap',
+      kind: 'tool_output',
+      path: '/tmp/scan.xml',
+      capturedAt: now(),
+    });
     const service = serviceRepo.create({
-      hostId: host.id, transport: 'tcp', port: 80, appProto: 'http',
-      protoConfidence: 'high', state: 'open', evidenceArtifactId: artifact.id,
+      hostId: host.id,
+      transport: 'tcp',
+      port: 80,
+      appProto: 'http',
+      protoConfidence: 'high',
+      state: 'open',
+      evidenceArtifactId: artifact.id,
     });
     credentialRepo.create({
-      serviceId: service.id, username: 'admin', secret: 'pass',
-      secretType: 'password', source: 'manual', confidence: 'high',
+      serviceId: service.id,
+      username: 'admin',
+      secret: 'pass',
+      secretType: 'password',
+      source: 'manual',
+      confidence: 'high',
       evidenceArtifactId: artifact.id,
     });
 
@@ -178,19 +229,41 @@ describe('MCP Server', () => {
     const serviceRepo = new ServiceRepository(db);
     const vulnRepo = new VulnerabilityRepository(db);
 
-    const host = hostRepo.create({ authorityKind: 'IP', authority: '10.0.0.1', resolvedIpsJson: '[]' });
-    const artifact = artifactRepo.create({ tool: 'nmap', kind: 'tool_output', path: '/tmp/scan.xml', capturedAt: now() });
+    const host = hostRepo.create({
+      authorityKind: 'IP',
+      authority: '10.0.0.1',
+      resolvedIpsJson: '[]',
+    });
+    const artifact = artifactRepo.create({
+      tool: 'nmap',
+      kind: 'tool_output',
+      path: '/tmp/scan.xml',
+      capturedAt: now(),
+    });
     const service = serviceRepo.create({
-      hostId: host.id, transport: 'tcp', port: 80, appProto: 'http',
-      protoConfidence: 'high', state: 'open', evidenceArtifactId: artifact.id,
+      hostId: host.id,
+      transport: 'tcp',
+      port: 80,
+      appProto: 'http',
+      protoConfidence: 'high',
+      state: 'open',
+      evidenceArtifactId: artifact.id,
     });
     vulnRepo.create({
-      serviceId: service.id, vulnType: 'sqli', title: 'SQL Injection',
-      severity: 'critical', confidence: 'high', evidenceArtifactId: artifact.id,
+      serviceId: service.id,
+      vulnType: 'sqli',
+      title: 'SQL Injection',
+      severity: 'critical',
+      confidence: 'high',
+      evidenceArtifactId: artifact.id,
     });
     vulnRepo.create({
-      serviceId: service.id, vulnType: 'info_disclosure', title: 'Info Leak',
-      severity: 'low', confidence: 'high', evidenceArtifactId: artifact.id,
+      serviceId: service.id,
+      vulnType: 'info_disclosure',
+      title: 'Info Leak',
+      severity: 'low',
+      confidence: 'high',
+      evidenceArtifactId: artifact.id,
     });
 
     const result = await client.callTool({
@@ -235,11 +308,25 @@ describe('MCP Server', () => {
     const artifactRepo = new ArtifactRepository(db);
     const serviceRepo = new ServiceRepository(db);
 
-    const host = hostRepo.create({ authorityKind: 'IP', authority: '10.0.0.1', resolvedIpsJson: '[]' });
-    const artifact = artifactRepo.create({ tool: 'nmap', kind: 'tool_output', path: '/tmp/scan.xml', capturedAt: now() });
+    const host = hostRepo.create({
+      authorityKind: 'IP',
+      authority: '10.0.0.1',
+      resolvedIpsJson: '[]',
+    });
+    const artifact = artifactRepo.create({
+      tool: 'nmap',
+      kind: 'tool_output',
+      path: '/tmp/scan.xml',
+      capturedAt: now(),
+    });
     const service = serviceRepo.create({
-      hostId: host.id, transport: 'tcp', port: 80, appProto: 'http',
-      protoConfidence: 'high', state: 'open', evidenceArtifactId: artifact.id,
+      hostId: host.id,
+      transport: 'tcp',
+      port: 80,
+      appProto: 'http',
+      protoConfidence: 'high',
+      state: 'open',
+      evidenceArtifactId: artifact.id,
     });
 
     const result = await client.callTool({
@@ -347,11 +434,25 @@ describe('MCP Server', () => {
     const artifactRepo = new ArtifactRepository(db);
     const serviceRepo = new ServiceRepository(db);
 
-    const host = hostRepo.create({ authorityKind: 'IP', authority: '10.0.0.1', resolvedIpsJson: '[]' });
-    const artifact = artifactRepo.create({ tool: 'nmap', kind: 'tool_output', path: '/tmp/scan.xml', capturedAt: now() });
+    const host = hostRepo.create({
+      authorityKind: 'IP',
+      authority: '10.0.0.1',
+      resolvedIpsJson: '[]',
+    });
+    const artifact = artifactRepo.create({
+      tool: 'nmap',
+      kind: 'tool_output',
+      path: '/tmp/scan.xml',
+      capturedAt: now(),
+    });
     serviceRepo.create({
-      hostId: host.id, transport: 'tcp', port: 80, appProto: 'http',
-      protoConfidence: 'high', state: 'open', evidenceArtifactId: artifact.id,
+      hostId: host.id,
+      transport: 'tcp',
+      port: 80,
+      appProto: 'http',
+      protoConfidence: 'high',
+      state: 'open',
+      evidenceArtifactId: artifact.id,
     });
 
     const program = [
@@ -398,11 +499,25 @@ describe('MCP Server', () => {
     const artifactRepo = new ArtifactRepository(db);
     const serviceRepo = new ServiceRepository(db);
 
-    const host = hostRepo.create({ authorityKind: 'IP', authority: '10.0.0.1', resolvedIpsJson: '[]' });
-    const artifact = artifactRepo.create({ tool: 'nmap', kind: 'tool_output', path: '/tmp/scan.xml', capturedAt: now() });
+    const host = hostRepo.create({
+      authorityKind: 'IP',
+      authority: '10.0.0.1',
+      resolvedIpsJson: '[]',
+    });
+    const artifact = artifactRepo.create({
+      tool: 'nmap',
+      kind: 'tool_output',
+      path: '/tmp/scan.xml',
+      capturedAt: now(),
+    });
     serviceRepo.create({
-      hostId: host.id, transport: 'tcp', port: 443, appProto: 'https',
-      protoConfidence: 'high', state: 'open', evidenceArtifactId: artifact.id,
+      hostId: host.id,
+      transport: 'tcp',
+      port: 443,
+      appProto: 'https',
+      protoConfidence: 'high',
+      state: 'open',
+      evidenceArtifactId: artifact.id,
     });
 
     const result = await client.callTool({

--- a/tests/parser/ffuf-parser.test.ts
+++ b/tests/parser/ffuf-parser.test.ts
@@ -25,19 +25,21 @@ function buildFfufJson(overrides: {
   });
 }
 
-function buildResult(overrides: Partial<{
-  input: Record<string, string>;
-  position: number;
-  status: number;
-  length: number;
-  words: number;
-  lines: number;
-  'content-type': string;
-  redirectlocation: string;
-  resultfile: string;
-  url: string;
-  host: string;
-}>): Record<string, unknown> {
+function buildResult(
+  overrides: Partial<{
+    input: Record<string, string>;
+    position: number;
+    status: number;
+    length: number;
+    words: number;
+    lines: number;
+    'content-type': string;
+    redirectlocation: string;
+    resultfile: string;
+    url: string;
+    host: string;
+  }>,
+): Record<string, unknown> {
   return {
     input: { FUZZ: 'test' },
     position: 1,
@@ -150,7 +152,8 @@ describe('parseFfufJson', () => {
   // -----------------------------------------------------------------------
   it('URL のクエリパラメータを inputs に変換する', () => {
     const json = buildFfufJson({
-      commandline: 'ffuf -u "http://10.0.0.1:80/search?q=FUZZ" -w wordlist.txt -o output.json -of json',
+      commandline:
+        'ffuf -u "http://10.0.0.1:80/search?q=FUZZ" -w wordlist.txt -o output.json -of json',
       url: 'http://10.0.0.1:80/search?q=FUZZ',
       method: 'GET',
       results: [
@@ -277,7 +280,8 @@ describe('parseFfufJson', () => {
   // -----------------------------------------------------------------------
   it('POST リクエストのファジング結果をパースする', () => {
     const json = buildFfufJson({
-      commandline: 'ffuf -u http://10.0.0.1:80/api/login -X POST -d "username=FUZZ" -w wordlist.txt -o output.json -of json',
+      commandline:
+        'ffuf -u http://10.0.0.1:80/api/login -X POST -d "username=FUZZ" -w wordlist.txt -o output.json -of json',
       url: 'http://10.0.0.1:80/api/login',
       method: 'POST',
       results: [
@@ -320,7 +324,8 @@ describe('parseFfufJson', () => {
   // -----------------------------------------------------------------------
   it('複数のクエリパラメータを持つ URL を処理する', () => {
     const json = buildFfufJson({
-      commandline: 'ffuf -u "http://10.0.0.1:80/api?user=FUZZ&role=admin" -w wordlist.txt -o output.json -of json',
+      commandline:
+        'ffuf -u "http://10.0.0.1:80/api?user=FUZZ&role=admin" -w wordlist.txt -o output.json -of json',
       url: 'http://10.0.0.1:80/api?user=FUZZ&role=admin',
       method: 'GET',
       results: [

--- a/tests/parser/nmap-parser.test.ts
+++ b/tests/parser/nmap-parser.test.ts
@@ -207,7 +207,7 @@ describe('parseNmapXml', () => {
 
     it('serviceObservations に OS 情報が含まれる', () => {
       const osObs = result.serviceObservations.find(
-        (o) => o.key === 'os' && o.hostAuthority === '10.0.0.1'
+        (o) => o.key === 'os' && o.hostAuthority === '10.0.0.1',
       );
       expect(osObs).toBeDefined();
       expect(osObs).toMatchObject({
@@ -257,9 +257,7 @@ describe('parseNmapXml', () => {
     });
 
     it('10.0.0.1 のサービスは SSH の1件のみ', () => {
-      const host1Services = result.services.filter(
-        (s) => s.hostAuthority === '10.0.0.1'
-      );
+      const host1Services = result.services.filter((s) => s.hostAuthority === '10.0.0.1');
       expect(host1Services).toHaveLength(1);
       expect(host1Services[0]).toMatchObject({
         port: 22,
@@ -268,9 +266,7 @@ describe('parseNmapXml', () => {
     });
 
     it('10.0.0.2 のサービスは HTTP と MySQL の2件', () => {
-      const host2Services = result.services.filter(
-        (s) => s.hostAuthority === '10.0.0.2'
-      );
+      const host2Services = result.services.filter((s) => s.hostAuthority === '10.0.0.2');
       expect(host2Services).toHaveLength(2);
 
       const ports = host2Services.map((s) => s.port).sort((a, b) => a - b);

--- a/tests/parser/nuclei-parser.test.ts
+++ b/tests/parser/nuclei-parser.test.ts
@@ -313,9 +313,7 @@ describe('parseNucleiJsonl', () => {
     });
 
     it('vulnerabilityTitle が脆弱性の title と一致する', () => {
-      expect(result.cves[0]!.vulnerabilityTitle).toBe(
-        'Apache HTTP Server Path Traversal',
-      );
+      expect(result.cves[0]!.vulnerabilityTitle).toBe('Apache HTTP Server Path Traversal');
     });
   });
 
@@ -334,9 +332,7 @@ describe('parseNucleiJsonl', () => {
     });
 
     it('path が matched-at URL のパス部分と一致する', () => {
-      expect(result.httpEndpoints[0]!.path).toBe(
-        '/icons/.%2e/%2e%2e/%2e%2e/etc/passwd',
-      );
+      expect(result.httpEndpoints[0]!.path).toBe('/icons/.%2e/%2e%2e/%2e%2e/etc/passwd');
     });
 
     it('hostAuthority と port が正しい', () => {
@@ -421,9 +417,7 @@ describe('parseNucleiJsonl', () => {
     });
 
     it('空行を含む JSONL を正常にパースする', () => {
-      const jsonl = [TECH_DETECT_LINE, '', '  ', CVE_FINDING_LINE, ''].join(
-        '\n',
-      );
+      const jsonl = [TECH_DETECT_LINE, '', '  ', CVE_FINDING_LINE, ''].join('\n');
       const result = parseNucleiJsonl(jsonl);
 
       expect(result.hosts).toHaveLength(2);


### PR DESCRIPTION
## Summary

- `package.json` の format スクリプトのグロブパターンをシングルクォートからダブルクォートに変更（Windows 互換性対応）
- 全 44 ファイルに Prettier フォーマットを適用

## 原因

Windows の bash ではシングルクォート `'src/**/*.ts'` がシェルで展開されず、Prettier がファイルを見つけられなかった。CI の Linux 環境では正しく展開され、未フォーマットの 44 ファイルを検出して失敗していた。

## Test plan

- [ ] CI の `format:check` ステップが green になること
- [ ] 全 309 テストがパスすること

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)