### PR TITLE
Add versioned database migration system

### DIFF
--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,11 +1,52 @@
 import type Database from 'better-sqlite3';
 import { SCHEMA_SQL } from './schema.js';
+import {
+  getSchemaVersion,
+  setSchemaVersion,
+  runMigrations,
+  LATEST_VERSION,
+} from './migrations/index.js';
 
 /**
- * Run schema SQL to create all tables.
- * Enables foreign key enforcement before executing the schema.
+ * Migrate the database to the latest schema version.
+ *
+ * - New database (user_version = 0, no tables): runs full schema SQL and sets version.
+ * - Existing database (user_version = 0, has tables): runs incremental migrations.
+ * - Already up-to-date (user_version = LATEST_VERSION): no-op.
  */
 export function migrateDatabase(db: Database.Database): void {
   db.pragma('foreign_keys = ON');
-  db.exec(SCHEMA_SQL);
+
+  const currentVersion = getSchemaVersion(db);
+
+  if (currentVersion >= LATEST_VERSION) {
+    // Already up to date — but still run schema SQL for IF NOT EXISTS safety
+    db.exec(SCHEMA_SQL);
+    return;
+  }
+
+  if (currentVersion === 0) {
+    // Check if this is a truly new DB or an existing v0 DB
+    const tableCount = (
+      db
+        .prepare(
+          "SELECT COUNT(*) AS cnt FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+        )
+        .get() as { cnt: number }
+    ).cnt;
+
+    if (tableCount === 0) {
+      // Brand new database: run full schema and set version
+      db.exec(SCHEMA_SQL);
+      setSchemaVersion(db, LATEST_VERSION);
+      return;
+    }
+
+    // Existing v0 database: run incremental migrations
+    runMigrations(db, currentVersion);
+    return;
+  }
+
+  // Partially migrated: run remaining migrations
+  runMigrations(db, currentVersion);
 }

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -1,0 +1,55 @@
+/**
+ * sonobat — Database migration registry
+ *
+ * Manages versioned migrations using SQLite's PRAGMA user_version.
+ * Each migration has a version number and an up() function.
+ */
+
+import type Database from 'better-sqlite3';
+import v1 from './v1.js';
+
+export interface Migration {
+  version: number;
+  description: string;
+  up(db: Database.Database): void;
+}
+
+/** All migrations in order. Must be sorted by version ascending. */
+const migrations: Migration[] = [v1];
+
+/** The latest schema version (after all migrations applied). */
+export const LATEST_VERSION: number =
+  migrations.length > 0 ? migrations[migrations.length - 1].version : 0;
+
+/**
+ * Get the current schema version from the database.
+ */
+export function getSchemaVersion(db: Database.Database): number {
+  const row = db.prepare('PRAGMA user_version').get() as {
+    user_version: number;
+  };
+  return row.user_version;
+}
+
+/**
+ * Set the schema version in the database.
+ */
+export function setSchemaVersion(db: Database.Database, version: number): void {
+  db.pragma(`user_version = ${version}`);
+}
+
+/**
+ * Run all pending migrations from currentVersion to LATEST_VERSION.
+ * Each migration runs inside a transaction for safety.
+ */
+export function runMigrations(db: Database.Database, currentVersion: number): void {
+  for (const migration of migrations) {
+    if (migration.version > currentVersion) {
+      const runMigration = db.transaction(() => {
+        migration.up(db);
+      });
+      runMigration();
+    }
+  }
+  setSchemaVersion(db, LATEST_VERSION);
+}

--- a/src/db/migrations/v1.ts
+++ b/src/db/migrations/v1.ts
@@ -1,0 +1,32 @@
+/**
+ * Migration v1: Add datalog_rules table
+ *
+ * This migration adds the datalog_rules table for storing
+ * custom Datalog rules created by humans or AI agents.
+ */
+
+import type Database from 'better-sqlite3';
+import type { Migration } from './index.js';
+
+const migration: Migration = {
+  version: 1,
+  description: 'Add datalog_rules table',
+  up(db: Database.Database): void {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS datalog_rules (
+        id            TEXT PRIMARY KEY,
+        name          TEXT NOT NULL UNIQUE,
+        description   TEXT,
+        rule_text     TEXT NOT NULL,
+        generated_by  TEXT NOT NULL,            -- "human" | "ai" | "preset"
+        is_preset     INTEGER NOT NULL DEFAULT 0,
+        created_at    TEXT NOT NULL,
+        updated_at    TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_datalog_rules_name ON datalog_rules(name);
+    `);
+  },
+};
+
+export default migration;


### PR DESCRIPTION
## Summary

- `PRAGMA user_version` を使ったバージョン付きマイグレーションシステムを導入
- 新規DB → 全スキーマ実行 + バージョン設定
- 既存v0 DB → テーブル数で判定し、差分マイグレーション実行
- v1マイグレーション: `datalog_rules` テーブル追加（既存DBの場合）
- 各マイグレーションはトランザクションで実行（安全性）

## 変更ファイル

- `src/db/migrate.ts` — バージョン判定ロジック追加
- `src/db/migrations/index.ts` — マイグレーションレジストリ（new）
- `src/db/migrations/v1.ts` — datalog_rules テーブル追加（new）
- `tests/db/migrate.test.ts` — 3テスト追加（312 total）

## Test plan

- [x] 新規DB: 全テーブル作成 + user_version設定
- [x] 冪等性: 2回実行しても問題なし
- [x] v0→v1: 既存DBにdatalog_rulesが追加され、既存データは保持
- [x] 全312テストパス

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)