### PR TITLE
fix: read MCP server version from package.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,31 @@
 ## プロジェクト概要
 
 sonobat — 自律ペネトレーションテストのための AttackDataGraph ツール。
-TypeScript で実装。SQLite を永続化ストアとし、CLI を基本インターフェースとする。
+TypeScript で実装。SQLite を永続化ストアとし、MCP Server を LLM Agent 向けインターフェースとする。
 
 詳細は `docs/architecture.md`
+
+---
+
+## 実装状況 (v0.5.0)
+
+### 実装済み
+- **DB スキーマ**: graph-native (nodes + edges) + 運用テーブル (engagements, runs, action_queue, action_executions, findings, finding_events, risk_snapshots)
+- **マイグレーション**: v0〜v5（v4 で旧 12 テーブル → nodes/edges 移行、v5 で運用テーブル + backfill）
+- **Parser**: nmap XML, ffuf JSON, nuclei JSONL
+- **Engine**: normalizer（パーサー出力 → nodes/edges 変換）, proposer（ギャップベース次アクション提案）, ingest（ファイル取込パイプライン）
+- **Graph traversal**: SQLite CTE 再帰クエリ、attack_paths プリセット 6 種
+- **RAG (Knowledge Base)**: HackTricks auto-clone + 増分インデックス + FTS5 全文検索 (BM25)
+- **MCP Server**: 6 tools (query, mutate, ingest_file, propose, search_kb, index_kb) + 4 resources
+- **Repository 層**: node, edge, graph-query, technique-doc
+
+### 未実装（v5 スキーマはあるがアプリケーションコードなし）
+- 運用テーブルの Repository 層 (engagement, run, action_queue, finding, risk_snapshot)
+- スケジューラ、アクションキュー処理、Finding マテリアライザ、リスク集計
+- 運用テーブル用 MCP Tools
+
+### 廃止済み
+- datalog_rules テーブル（v1 で作成 → v4 で DROP。代替: proposer + CTE attack_paths）
 
 ---
 
@@ -61,8 +83,8 @@ sonobat/
 ├── src/
 │   ├── index.ts              # エントリポイント
 │   ├── db/                   # SQLite スキーマ・マイグレーション・リポジトリ
-│   │   ├── schema.ts         # CREATE TABLE 文の定義
 │   │   ├── migrate.ts        # マイグレーション実行
+│   │   ├── migrations/      # バージョン付きマイグレーション (v0〜v5)
 │   │   └── repository/       # テーブルごとの CRUD 操作
 │   ├── parser/               # Artifact パーサー（nmap, ffuf, nuclei）
 │   ├── engine/               # 正規化・propose ロジック

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonobat",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AttackDataGraph for autonomous penetration testing",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,15 +5,23 @@
  * stdio トランスポートで LLM Agent と接続する。
  */
 
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { migrateDatabase } from './db/migrate.js';
 import { createMcpServer } from './mcp/server.js';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8')) as {
+  version: string;
+};
+
 const DB_PATH = process.env['SONOBAT_DB_PATH'] ?? 'sonobat.db';
 const db = new Database(DB_PATH);
 migrateDatabase(db);
 
-const server = createMcpServer(db);
+const server = createMcpServer(db, pkg.version);
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -17,12 +17,13 @@ import { registerResources } from './resources.js';
  * Create a fully configured MCP server with all sonobat tools and resources.
  *
  * @param db - The better-sqlite3 database instance
+ * @param version - Package version string (read from package.json by caller)
  * @returns Configured McpServer instance
  */
-export function createMcpServer(db: Database.Database): McpServer {
+export function createMcpServer(db: Database.Database, version?: string): McpServer {
   const server = new McpServer({
     name: 'sonobat',
-    version: '0.4.0',
+    version: version ?? '0.0.0',
   });
 
   // Register tools (6 tools total)


### PR DESCRIPTION
## Summary

- MCP Server のバージョンがハードコード (`0.4.0`) だったのを `package.json` から動的に読み取るよう修正
- CLAUDE.md に実装状況セクションを追加（ハルシネーション防止）
- version 0.5.1 バンプ

## Test plan

- [x] `npm test` — 356 テスト全 Green
- [x] `npm run typecheck` — 型エラーなし
- [x] `npm run build` — ビルド成功、`run_datalog` がバンドルに含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)