### PR TITLE
Add operational table Repositories + MCP tools (ops, findings)

### DIFF
--- a/src/db/migrations/v5.ts
+++ b/src/db/migrations/v5.ts
@@ -236,9 +236,8 @@ const migration: Migration = {
     // -------------------------------------------------------
     // Part D: 既存データの backfill
     // -------------------------------------------------------
-    const scanCount = (
-      db.prepare('SELECT COUNT(*) AS cnt FROM scans').get() as { cnt: number }
-    ).cnt;
+    const scanCount = (db.prepare('SELECT COUNT(*) AS cnt FROM scans').get() as { cnt: number })
+      .cnt;
 
     if (scanCount > 0) {
       const now = new Date().toISOString();

--- a/src/db/repository/action-execution-repository.ts
+++ b/src/db/repository/action-execution-repository.ts
@@ -1,0 +1,241 @@
+/**
+ * sonobat — ActionExecutionRepository
+ *
+ * action_executions テーブルに対する CRUD 操作を提供する。
+ * snake_case (DB) <-> camelCase (TypeScript) の変換を内部で行う。
+ */
+
+import type Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import type { ActionExecution, CreateExecutionInput } from '../../types/operational.js';
+
+// ---------------------------------------------------------------------------
+// DB row 型
+// ---------------------------------------------------------------------------
+
+/** better-sqlite3 から返る action_executions テーブルの行形状 */
+interface ActionExecutionRow {
+  id: string;
+  action_id: string;
+  run_id: string | null;
+  executor: string;
+  command: string | null;
+  input_json: string;
+  output_json: string;
+  stdout_artifact_id: string | null;
+  stderr_artifact_id: string | null;
+  exit_code: number | null;
+  error_type: string | null;
+  error_message: string | null;
+  started_at: string;
+  finished_at: string | null;
+  duration_ms: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Row → ActionExecution 変換
+// ---------------------------------------------------------------------------
+
+/** snake_case DB row を camelCase ActionExecution にマッピング */
+function rowToExecution(row: ActionExecutionRow): ActionExecution {
+  return {
+    id: row.id,
+    actionId: row.action_id,
+    ...(row.run_id !== null ? { runId: row.run_id } : {}),
+    executor: row.executor,
+    ...(row.command !== null ? { command: row.command } : {}),
+    inputJson: row.input_json,
+    outputJson: row.output_json,
+    ...(row.stdout_artifact_id !== null ? { stdoutArtifactId: row.stdout_artifact_id } : {}),
+    ...(row.stderr_artifact_id !== null ? { stderrArtifactId: row.stderr_artifact_id } : {}),
+    ...(row.exit_code !== null ? { exitCode: row.exit_code } : {}),
+    ...(row.error_type !== null ? { errorType: row.error_type } : {}),
+    ...(row.error_message !== null ? { errorMessage: row.error_message } : {}),
+    startedAt: row.started_at,
+    ...(row.finished_at !== null ? { finishedAt: row.finished_at } : {}),
+    ...(row.duration_ms !== null ? { durationMs: row.duration_ms } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Complete output 型
+// ---------------------------------------------------------------------------
+
+/** complete() に渡す出力パラメータ */
+export interface CompleteExecutionOutput {
+  outputJson?: string;
+  exitCode?: number;
+  errorType?: string;
+  errorMessage?: string;
+  stdoutArtifactId?: string;
+  stderrArtifactId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// ActionExecutionRepository
+// ---------------------------------------------------------------------------
+
+/**
+ * action_executions テーブルの CRUD リポジトリ。
+ *
+ * - ID は crypto.randomUUID() で生成
+ * - started_at は create 時に自動設定
+ * - complete() で finished_at, duration_ms を自動計算
+ */
+export class ActionExecutionRepository {
+  private readonly db: Database.Database;
+
+  private readonly insertStmt: Database.Statement;
+  private readonly selectByIdStmt: Database.Statement;
+  private readonly selectByActionStmt: Database.Statement;
+  private readonly selectByRunStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+
+    this.insertStmt = this.db.prepare(
+      `INSERT INTO action_executions (id, action_id, run_id, executor, command, input_json, output_json, started_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    this.selectByIdStmt = this.db.prepare(
+      `SELECT id, action_id, run_id, executor, command, input_json, output_json,
+              stdout_artifact_id, stderr_artifact_id, exit_code, error_type, error_message,
+              started_at, finished_at, duration_ms
+       FROM action_executions WHERE id = ?`,
+    );
+
+    this.selectByActionStmt = this.db.prepare(
+      `SELECT id, action_id, run_id, executor, command, input_json, output_json,
+              stdout_artifact_id, stderr_artifact_id, exit_code, error_type, error_message,
+              started_at, finished_at, duration_ms
+       FROM action_executions WHERE action_id = ? ORDER BY started_at DESC`,
+    );
+
+    this.selectByRunStmt = this.db.prepare(
+      `SELECT id, action_id, run_id, executor, command, input_json, output_json,
+              stdout_artifact_id, stderr_artifact_id, exit_code, error_type, error_message,
+              started_at, finished_at, duration_ms
+       FROM action_executions WHERE run_id = ? ORDER BY started_at DESC`,
+    );
+  }
+
+  /**
+   * ActionExecution を新規作成して返す。
+   *
+   * - started_at は現在時刻に自動設定
+   * - inputJson デフォルト '{}'
+   * - outputJson デフォルト '{}'
+   */
+  create(input: CreateExecutionInput): ActionExecution {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const inputJson = input.inputJson ?? '{}';
+
+    this.insertStmt.run(
+      id,
+      input.actionId,
+      input.runId ?? null,
+      input.executor,
+      input.command ?? null,
+      inputJson,
+      '{}', // output_json default
+      now, // started_at
+    );
+
+    return {
+      id,
+      actionId: input.actionId,
+      ...(input.runId !== undefined ? { runId: input.runId } : {}),
+      executor: input.executor,
+      ...(input.command !== undefined ? { command: input.command } : {}),
+      inputJson,
+      outputJson: '{}',
+      startedAt: now,
+    };
+  }
+
+  /**
+   * ID で ActionExecution を取得する。存在しなければ undefined。
+   */
+  findById(id: string): ActionExecution | undefined {
+    const row = this.selectByIdStmt.get(id) as ActionExecutionRow | undefined;
+    if (row === undefined) {
+      return undefined;
+    }
+    return rowToExecution(row);
+  }
+
+  /**
+   * action_id で ActionExecution 一覧を取得する。
+   * ORDER BY started_at DESC。
+   */
+  findByAction(actionId: string): ActionExecution[] {
+    const rows = this.selectByActionStmt.all(actionId) as ActionExecutionRow[];
+    return rows.map(rowToExecution);
+  }
+
+  /**
+   * run_id で ActionExecution 一覧を取得する。
+   * ORDER BY started_at DESC。
+   */
+  findByRun(runId: string): ActionExecution[] {
+    const rows = this.selectByRunStmt.all(runId) as ActionExecutionRow[];
+    return rows.map(rowToExecution);
+  }
+
+  /**
+   * ActionExecution を完了状態にする。
+   *
+   * - finished_at を現在時刻に設定
+   * - duration_ms を started_at からの差分で自動計算
+   * - outputJson, exitCode, errorType, errorMessage を更新
+   *
+   * @returns 更新後の ActionExecution。id が存在しなければ undefined。
+   */
+  complete(id: string, output: CompleteExecutionOutput): ActionExecution | undefined {
+    const existing = this.findById(id);
+    if (existing === undefined) {
+      return undefined;
+    }
+
+    const now = new Date();
+    const finishedAt = now.toISOString();
+    const durationMs = now.getTime() - new Date(existing.startedAt).getTime();
+
+    const setClauses: string[] = ['finished_at = ?', 'duration_ms = ?'];
+    const params: unknown[] = [finishedAt, durationMs];
+
+    if (output.outputJson !== undefined) {
+      setClauses.push('output_json = ?');
+      params.push(output.outputJson);
+    }
+    if (output.exitCode !== undefined) {
+      setClauses.push('exit_code = ?');
+      params.push(output.exitCode);
+    }
+    if (output.errorType !== undefined) {
+      setClauses.push('error_type = ?');
+      params.push(output.errorType);
+    }
+    if (output.errorMessage !== undefined) {
+      setClauses.push('error_message = ?');
+      params.push(output.errorMessage);
+    }
+    if (output.stdoutArtifactId !== undefined) {
+      setClauses.push('stdout_artifact_id = ?');
+      params.push(output.stdoutArtifactId);
+    }
+    if (output.stderrArtifactId !== undefined) {
+      setClauses.push('stderr_artifact_id = ?');
+      params.push(output.stderrArtifactId);
+    }
+
+    params.push(id);
+
+    const sql = `UPDATE action_executions SET ${setClauses.join(', ')} WHERE id = ?`;
+    this.db.prepare(sql).run(...params);
+
+    return this.findById(id);
+  }
+}

--- a/src/db/repository/action-queue-repository.ts
+++ b/src/db/repository/action-queue-repository.ts
@@ -170,7 +170,8 @@ export class ActionQueueRepository {
     );
 
     this.cancelStmt = this.db.prepare(
-      `UPDATE action_queue SET state = 'cancelled', updated_at = ? WHERE id = ?`,
+      `UPDATE action_queue SET state = 'cancelled', updated_at = ?
+       WHERE id = ? AND state IN ('queued', 'running')`,
     );
 
     // fail トランザクション: リトライ可能か dead letter かを判定

--- a/src/db/repository/action-queue-repository.ts
+++ b/src/db/repository/action-queue-repository.ts
@@ -1,0 +1,348 @@
+/**
+ * sonobat — ActionQueueRepository
+ *
+ * action_queue テーブルに対する CRUD + ポーリング操作。
+ * キューベースの非同期タスク管理を提供する。
+ */
+
+import type Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import type { ActionQueueItem, CreateActionInput } from '../../types/operational.js';
+
+// ---------------------------------------------------------------------------
+// DB row 型
+// ---------------------------------------------------------------------------
+
+/** better-sqlite3 から返る action_queue テーブルの行形状 */
+interface ActionQueueRow {
+  id: string;
+  engagement_id: string;
+  run_id: string | null;
+  parent_action_id: string | null;
+  kind: string;
+  priority: number;
+  dedupe_key: string;
+  params_json: string;
+  state: string;
+  attempt_count: number;
+  max_attempts: number;
+  available_at: string;
+  lease_owner: string | null;
+  lease_expires_at: string | null;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Row → ActionQueueItem 変換
+// ---------------------------------------------------------------------------
+
+/** snake_case DB row を camelCase ActionQueueItem にマッピング */
+function rowToActionQueueItem(row: ActionQueueRow): ActionQueueItem {
+  return {
+    id: row.id,
+    engagementId: row.engagement_id,
+    ...(row.run_id !== null ? { runId: row.run_id } : {}),
+    ...(row.parent_action_id !== null ? { parentActionId: row.parent_action_id } : {}),
+    kind: row.kind,
+    priority: row.priority,
+    dedupeKey: row.dedupe_key,
+    paramsJson: row.params_json,
+    state: row.state,
+    attemptCount: row.attempt_count,
+    maxAttempts: row.max_attempts,
+    availableAt: row.available_at,
+    ...(row.lease_owner !== null ? { leaseOwner: row.lease_owner } : {}),
+    ...(row.lease_expires_at !== null ? { leaseExpiresAt: row.lease_expires_at } : {}),
+    ...(row.last_error !== null ? { lastError: row.last_error } : {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ActionQueueRepository
+// ---------------------------------------------------------------------------
+
+/**
+ * action_queue テーブルの CRUD + ポーリング リポジトリ。
+ *
+ * - デフォルト値: priority=100, state='queued', paramsJson='{}', maxAttempts=3, availableAt=now
+ * - ID は crypto.randomUUID() で生成
+ * - poll() はアトミックな UPDATE ... RETURNING で排他的リース取得
+ * - fail() はリトライ回数に応じてバックオフ or dead letter
+ */
+export class ActionQueueRepository {
+  private readonly db: Database.Database;
+
+  private readonly insertStmt: Database.Statement;
+  private readonly selectByIdStmt: Database.Statement;
+  private readonly pollStmt: Database.Statement;
+  private readonly completeStmt: Database.Statement;
+  private readonly requeueStmt: Database.Statement;
+  private readonly deadLetterStmt: Database.Statement;
+  private readonly selectByEngagementStmt: Database.Statement;
+  private readonly selectByEngagementStateStmt: Database.Statement;
+  private readonly cancelStmt: Database.Statement;
+
+  private readonly failTx: Database.Transaction<(id: string, error: string) => boolean>;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+
+    this.insertStmt = this.db.prepare(
+      `INSERT INTO action_queue
+         (id, engagement_id, run_id, parent_action_id, kind, priority,
+          dedupe_key, params_json, state, attempt_count, max_attempts,
+          available_at, lease_owner, lease_expires_at, last_error,
+          created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    this.selectByIdStmt = this.db.prepare(
+      `SELECT id, engagement_id, run_id, parent_action_id, kind, priority,
+              dedupe_key, params_json, state, attempt_count, max_attempts,
+              available_at, lease_owner, lease_expires_at, last_error,
+              created_at, updated_at
+       FROM action_queue WHERE id = ?`,
+    );
+
+    this.pollStmt = this.db.prepare(
+      `UPDATE action_queue
+       SET state = 'running',
+           lease_owner = ?,
+           lease_expires_at = ?,
+           attempt_count = attempt_count + 1,
+           updated_at = ?
+       WHERE id = (
+         SELECT id FROM action_queue
+         WHERE state = 'queued' AND available_at <= ?
+         ORDER BY priority ASC, created_at ASC
+         LIMIT 1
+       )
+       RETURNING *`,
+    );
+
+    this.completeStmt = this.db.prepare(
+      `UPDATE action_queue
+       SET state = 'succeeded', updated_at = ?
+       WHERE id = ? AND state = 'running'`,
+    );
+
+    this.requeueStmt = this.db.prepare(
+      `UPDATE action_queue
+       SET state = 'queued',
+           available_at = ?,
+           last_error = ?,
+           lease_owner = NULL,
+           lease_expires_at = NULL,
+           updated_at = ?
+       WHERE id = ?`,
+    );
+
+    this.deadLetterStmt = this.db.prepare(
+      `UPDATE action_queue
+       SET state = 'failed',
+           last_error = ?,
+           updated_at = ?
+       WHERE id = ?`,
+    );
+
+    this.selectByEngagementStmt = this.db.prepare(
+      `SELECT id, engagement_id, run_id, parent_action_id, kind, priority,
+              dedupe_key, params_json, state, attempt_count, max_attempts,
+              available_at, lease_owner, lease_expires_at, last_error,
+              created_at, updated_at
+       FROM action_queue
+       WHERE engagement_id = ?
+       ORDER BY created_at DESC`,
+    );
+
+    this.selectByEngagementStateStmt = this.db.prepare(
+      `SELECT id, engagement_id, run_id, parent_action_id, kind, priority,
+              dedupe_key, params_json, state, attempt_count, max_attempts,
+              available_at, lease_owner, lease_expires_at, last_error,
+              created_at, updated_at
+       FROM action_queue
+       WHERE engagement_id = ? AND state = ?
+       ORDER BY created_at DESC`,
+    );
+
+    this.cancelStmt = this.db.prepare(
+      `UPDATE action_queue SET state = 'cancelled', updated_at = ? WHERE id = ?`,
+    );
+
+    // fail トランザクション: リトライ可能か dead letter かを判定
+    this.failTx = this.db.transaction((id: string, error: string): boolean => {
+      const item = this.findById(id);
+      if (!item || item.state !== 'running') return false;
+
+      const now = new Date().toISOString();
+
+      if (item.attemptCount < item.maxAttempts) {
+        // リトライ可能: バックオフ付きで再キュー
+        const backoffSec = item.attemptCount * 30;
+        const availableAt = new Date(Date.now() + backoffSec * 1000).toISOString();
+        this.requeueStmt.run(availableAt, error, now, id);
+      } else {
+        // Dead letter: 最大リトライ回数に到達
+        this.deadLetterStmt.run(error, now, id);
+      }
+
+      return true;
+    });
+  }
+
+  /**
+   * アクションをキューに追加して返す。
+   *
+   * デフォルト値:
+   * - priority: 100
+   * - state: 'queued'
+   * - paramsJson: '{}'
+   * - maxAttempts: 3
+   * - availableAt: 現在時刻
+   */
+  enqueue(input: CreateActionInput): ActionQueueItem {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    const priority = input.priority ?? 100;
+    const state = input.state ?? 'queued';
+    const paramsJson = input.paramsJson ?? '{}';
+    const maxAttempts = input.maxAttempts ?? 3;
+    const availableAt = input.availableAt ?? now;
+
+    this.insertStmt.run(
+      id,
+      input.engagementId,
+      input.runId ?? null,
+      input.parentActionId ?? null,
+      input.kind,
+      priority,
+      input.dedupeKey,
+      paramsJson,
+      state,
+      0, // attempt_count
+      maxAttempts,
+      availableAt,
+      null, // lease_owner
+      null, // lease_expires_at
+      null, // last_error
+      now, // created_at
+      now, // updated_at
+    );
+
+    return {
+      id,
+      engagementId: input.engagementId,
+      ...(input.runId !== undefined ? { runId: input.runId } : {}),
+      ...(input.parentActionId !== undefined ? { parentActionId: input.parentActionId } : {}),
+      kind: input.kind,
+      priority,
+      dedupeKey: input.dedupeKey,
+      paramsJson,
+      state,
+      attemptCount: 0,
+      maxAttempts,
+      availableAt,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  /**
+   * ID でアクションを取得する。存在しなければ undefined。
+   */
+  findById(id: string): ActionQueueItem | undefined {
+    const row = this.selectByIdStmt.get(id) as ActionQueueRow | undefined;
+    if (row === undefined) {
+      return undefined;
+    }
+    return rowToActionQueueItem(row);
+  }
+
+  /**
+   * キューから次のアクションをポーリングする。
+   *
+   * アトミックに state='running' に遷移し、リースを設定する。
+   * available_at が現在時刻以前のもののうち、priority ASC → created_at ASC で最初の1件を取得。
+   *
+   * @param leaseOwner       リースオーナーの識別子（例: 'worker-1'）
+   * @param leaseDurationSec リース期間（秒）。デフォルト 300秒。
+   * @returns ポーリングしたアクション。キューが空なら undefined。
+   */
+  poll(leaseOwner: string, leaseDurationSec?: number): ActionQueueItem | undefined {
+    const duration = leaseDurationSec ?? 300;
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const leaseExpiresAt = new Date(now.getTime() + duration * 1000).toISOString();
+
+    const row = this.pollStmt.get(
+      leaseOwner,
+      leaseExpiresAt,
+      nowIso,
+      nowIso,
+    ) as ActionQueueRow | undefined;
+
+    if (row === undefined) {
+      return undefined;
+    }
+    return rowToActionQueueItem(row);
+  }
+
+  /**
+   * アクションを正常完了にする。
+   *
+   * state を 'succeeded' に遷移する。running 状態でない場合は更新されない。
+   *
+   * @returns 更新成功時 true、id が存在しないか running でない場合 false。
+   */
+  complete(id: string): boolean {
+    const now = new Date().toISOString();
+    const result = this.completeStmt.run(now, id);
+    return result.changes > 0;
+  }
+
+  /**
+   * アクションを失敗にする。
+   *
+   * attempt_count < max_attempts の場合: state='queued' に戻し、バックオフ付きで再スケジュール。
+   * attempt_count >= max_attempts の場合: state='failed'（dead letter）。
+   *
+   * @param id    アクション ID
+   * @param error エラーメッセージ
+   * @returns 更新成功時 true、id が存在しないか running でない場合 false。
+   */
+  fail(id: string, error: string): boolean {
+    return this.failTx(id, error);
+  }
+
+  /**
+   * エンゲージメントに紐づくアクション一覧を取得する。
+   *
+   * @param engagementId エンゲージメント ID
+   * @param state        フィルタする状態（省略時は全状態）
+   * @returns アクション一覧（created_at DESC 順）
+   */
+  findByEngagement(engagementId: string, state?: string): ActionQueueItem[] {
+    if (state !== undefined) {
+      const rows = this.selectByEngagementStateStmt.all(engagementId, state) as ActionQueueRow[];
+      return rows.map(rowToActionQueueItem);
+    }
+    const rows = this.selectByEngagementStmt.all(engagementId) as ActionQueueRow[];
+    return rows.map(rowToActionQueueItem);
+  }
+
+  /**
+   * アクションをキャンセルする。
+   *
+   * @returns キャンセル成功時 true、id が存在しない場合 false。
+   */
+  cancel(id: string): boolean {
+    const now = new Date().toISOString();
+    const result = this.cancelStmt.run(now, id);
+    return result.changes > 0;
+  }
+}

--- a/src/db/repository/action-queue-repository.ts
+++ b/src/db/repository/action-queue-repository.ts
@@ -280,12 +280,9 @@ export class ActionQueueRepository {
     const nowIso = now.toISOString();
     const leaseExpiresAt = new Date(now.getTime() + duration * 1000).toISOString();
 
-    const row = this.pollStmt.get(
-      leaseOwner,
-      leaseExpiresAt,
-      nowIso,
-      nowIso,
-    ) as ActionQueueRow | undefined;
+    const row = this.pollStmt.get(leaseOwner, leaseExpiresAt, nowIso, nowIso) as
+      | ActionQueueRow
+      | undefined;
 
     if (row === undefined) {
       return undefined;

--- a/src/db/repository/engagement-repository.ts
+++ b/src/db/repository/engagement-repository.ts
@@ -1,0 +1,227 @@
+/**
+ * sonobat — EngagementRepository
+ *
+ * engagements テーブルに対する CRUD 操作を提供する。
+ * snake_case (DB) ↔ camelCase (TypeScript) の変換を内部で行う。
+ */
+
+import type Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import type { Engagement, CreateEngagementInput } from '../../types/operational.js';
+
+// ---------------------------------------------------------------------------
+// DB row 型
+// ---------------------------------------------------------------------------
+
+/** better-sqlite3 から返る engagements テーブルの行形状 */
+interface EngagementRow {
+  id: string;
+  name: string;
+  environment: string;
+  scope_json: string;
+  policy_json: string;
+  schedule_cron: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Row → Engagement 変換
+// ---------------------------------------------------------------------------
+
+/** snake_case DB row を camelCase Engagement にマッピング */
+function rowToEngagement(row: EngagementRow): Engagement {
+  return {
+    id: row.id,
+    name: row.name,
+    environment: row.environment,
+    scopeJson: row.scope_json,
+    policyJson: row.policy_json,
+    ...(row.schedule_cron !== null ? { scheduleCron: row.schedule_cron } : {}),
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// camelCase → snake_case フィールドマッピング
+// ---------------------------------------------------------------------------
+
+/** CreateEngagementInput のキーから DB カラム名へのマッピング */
+const FIELD_TO_COLUMN: Record<string, string> = {
+  name: 'name',
+  environment: 'environment',
+  scopeJson: 'scope_json',
+  policyJson: 'policy_json',
+  scheduleCron: 'schedule_cron',
+  status: 'status',
+};
+
+// ---------------------------------------------------------------------------
+// EngagementRepository
+// ---------------------------------------------------------------------------
+
+/**
+ * engagements テーブルの CRUD リポジトリ。
+ *
+ * - デフォルト値: environment='stg', scopeJson='{}', policyJson='{}', status='active'
+ * - ID は crypto.randomUUID() で生成
+ * - update() は動的 SQL で提供されたフィールドのみ SET する
+ */
+export class EngagementRepository {
+  private readonly db: Database.Database;
+
+  private readonly insertStmt: Database.Statement;
+  private readonly selectByIdStmt: Database.Statement;
+  private readonly selectByStatusStmt: Database.Statement;
+  private readonly selectAllStmt: Database.Statement;
+  private readonly deleteStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+
+    this.insertStmt = this.db.prepare(
+      `INSERT INTO engagements (id, name, environment, scope_json, policy_json, schedule_cron, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    this.selectByIdStmt = this.db.prepare(
+      `SELECT id, name, environment, scope_json, policy_json, schedule_cron, status, created_at, updated_at
+       FROM engagements WHERE id = ?`,
+    );
+
+    this.selectByStatusStmt = this.db.prepare(
+      `SELECT id, name, environment, scope_json, policy_json, schedule_cron, status, created_at, updated_at
+       FROM engagements WHERE status = ?`,
+    );
+
+    this.selectAllStmt = this.db.prepare(
+      `SELECT id, name, environment, scope_json, policy_json, schedule_cron, status, created_at, updated_at
+       FROM engagements`,
+    );
+
+    this.deleteStmt = this.db.prepare(`DELETE FROM engagements WHERE id = ?`);
+  }
+
+  /**
+   * Engagement を新規作成して返す。
+   *
+   * デフォルト値:
+   * - environment: 'stg'
+   * - scopeJson: '{}'
+   * - policyJson: '{}'
+   * - status: 'active'
+   */
+  create(input: CreateEngagementInput): Engagement {
+    const id = crypto.randomUUID();
+    const timestamp = new Date().toISOString();
+
+    const environment = input.environment ?? 'stg';
+    const scopeJson = input.scopeJson ?? '{}';
+    const policyJson = input.policyJson ?? '{}';
+    const scheduleCron = input.scheduleCron ?? null;
+    const status = input.status ?? 'active';
+
+    this.insertStmt.run(
+      id,
+      input.name,
+      environment,
+      scopeJson,
+      policyJson,
+      scheduleCron,
+      status,
+      timestamp,
+      timestamp,
+    );
+
+    return {
+      id,
+      name: input.name,
+      environment,
+      scopeJson,
+      policyJson,
+      ...(scheduleCron !== null ? { scheduleCron } : {}),
+      status,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+  }
+
+  /**
+   * ID で Engagement を取得する。存在しなければ undefined。
+   */
+  findById(id: string): Engagement | undefined {
+    const row = this.selectByIdStmt.get(id) as EngagementRow | undefined;
+    if (row === undefined) {
+      return undefined;
+    }
+    return rowToEngagement(row);
+  }
+
+  /**
+   * status で Engagement 一覧を取得する。
+   */
+  findByStatus(status: string): Engagement[] {
+    const rows = this.selectByStatusStmt.all(status) as EngagementRow[];
+    return rows.map(rowToEngagement);
+  }
+
+  /**
+   * 全 Engagement を取得する。
+   */
+  list(): Engagement[] {
+    const rows = this.selectAllStmt.all() as EngagementRow[];
+    return rows.map(rowToEngagement);
+  }
+
+  /**
+   * Engagement の指定フィールドを更新する。
+   *
+   * 提供されたフィールドのみ SET し、updated_at を自動更新する。
+   * 存在しない ID の場合 undefined を返す。
+   */
+  update(id: string, fields: Partial<CreateEngagementInput>): Engagement | undefined {
+    // 更新対象のフィールドがなくても updated_at は更新する
+    const setClauses: string[] = [];
+    const params: unknown[] = [];
+
+    for (const [key, value] of Object.entries(fields)) {
+      const column = FIELD_TO_COLUMN[key];
+      if (column !== undefined) {
+        setClauses.push(`${column} = ?`);
+        params.push(value ?? null);
+      }
+    }
+
+    // updated_at は常に更新
+    const timestamp = new Date().toISOString();
+    setClauses.push('updated_at = ?');
+    params.push(timestamp);
+
+    // WHERE id = ?
+    params.push(id);
+
+    const sql = `UPDATE engagements SET ${setClauses.join(', ')} WHERE id = ?`;
+    const result = this.db.prepare(sql).run(...params);
+
+    if (result.changes === 0) {
+      return undefined;
+    }
+
+    return this.findById(id);
+  }
+
+  /**
+   * Engagement を削除する。
+   *
+   * CASCADE により関連する runs なども同時に削除される。
+   *
+   * @returns 削除成功時 true、id が存在しない場合 false。
+   */
+  delete(id: string): boolean {
+    const result = this.deleteStmt.run(id);
+    return result.changes > 0;
+  }
+}

--- a/src/db/repository/finding-repository.ts
+++ b/src/db/repository/finding-repository.ts
@@ -268,10 +268,7 @@ export class FindingRepository {
    * opts で state, severity を指定して絞り込み可能。
    * ORDER BY last_seen_at DESC。
    */
-  findByEngagement(
-    engagementId: string,
-    opts?: { state?: string; severity?: string },
-  ): Finding[] {
+  findByEngagement(engagementId: string, opts?: { state?: string; severity?: string }): Finding[] {
     const whereClauses: string[] = ['engagement_id = ?'];
     const params: unknown[] = [engagementId];
 

--- a/src/db/repository/finding-repository.ts
+++ b/src/db/repository/finding-repository.ts
@@ -1,0 +1,383 @@
+/**
+ * sonobat — FindingRepository
+ *
+ * findings + finding_events テーブルに対する CRUD 操作。
+ * 親子関係が強いため、一つの Repository で管理する。
+ */
+
+import type Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import type {
+  Finding,
+  UpsertFindingInput,
+  FindingEvent,
+  CreateFindingEventInput,
+} from '../../types/operational.js';
+
+// ---------------------------------------------------------------------------
+// DB row 型
+// ---------------------------------------------------------------------------
+
+/** better-sqlite3 から返る findings テーブルの行形状 */
+interface FindingRow {
+  id: string;
+  engagement_id: string;
+  canonical_key: string;
+  node_id: string | null;
+  title: string;
+  severity: string;
+  confidence: string;
+  state: string;
+  state_reason: string | null;
+  owner: string | null;
+  ticket_ref: string | null;
+  first_seen_run_id: string | null;
+  last_seen_run_id: string | null;
+  first_seen_at: string;
+  last_seen_at: string;
+  sla_due_at: string | null;
+  attrs_json: string;
+}
+
+/** better-sqlite3 から返る finding_events テーブルの行形状 */
+interface FindingEventRow {
+  id: string;
+  finding_id: string;
+  run_id: string | null;
+  event_type: string;
+  before_json: string;
+  after_json: string;
+  artifact_id: string | null;
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Row → Entity 変換
+// ---------------------------------------------------------------------------
+
+/** snake_case DB row を camelCase Finding にマッピング */
+function rowToFinding(row: FindingRow): Finding {
+  return {
+    id: row.id,
+    engagementId: row.engagement_id,
+    canonicalKey: row.canonical_key,
+    ...(row.node_id !== null ? { nodeId: row.node_id } : {}),
+    title: row.title,
+    severity: row.severity,
+    confidence: row.confidence,
+    state: row.state,
+    ...(row.state_reason !== null ? { stateReason: row.state_reason } : {}),
+    ...(row.owner !== null ? { owner: row.owner } : {}),
+    ...(row.ticket_ref !== null ? { ticketRef: row.ticket_ref } : {}),
+    ...(row.first_seen_run_id !== null ? { firstSeenRunId: row.first_seen_run_id } : {}),
+    ...(row.last_seen_run_id !== null ? { lastSeenRunId: row.last_seen_run_id } : {}),
+    firstSeenAt: row.first_seen_at,
+    lastSeenAt: row.last_seen_at,
+    ...(row.sla_due_at !== null ? { slaDueAt: row.sla_due_at } : {}),
+    attrsJson: row.attrs_json,
+  };
+}
+
+/** snake_case DB row を camelCase FindingEvent にマッピング */
+function rowToFindingEvent(row: FindingEventRow): FindingEvent {
+  return {
+    id: row.id,
+    findingId: row.finding_id,
+    ...(row.run_id !== null ? { runId: row.run_id } : {}),
+    eventType: row.event_type,
+    beforeJson: row.before_json,
+    afterJson: row.after_json,
+    ...(row.artifact_id !== null ? { artifactId: row.artifact_id } : {}),
+    createdAt: row.created_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// FindingRepository
+// ---------------------------------------------------------------------------
+
+/**
+ * findings + finding_events テーブルの CRUD リポジトリ。
+ *
+ * - upsert() は engagement_id + canonical_key の UNIQUE 制約を活用
+ * - finding_events は Finding のライフサイクルイベントを記録
+ * - ID は crypto.randomUUID() で生成
+ */
+export class FindingRepository {
+  private readonly db: Database.Database;
+
+  private readonly insertFindingStmt: Database.Statement;
+  private readonly selectFindingByIdStmt: Database.Statement;
+  private readonly deleteFindingStmt: Database.Statement;
+  private readonly updateLastSeenStmt: Database.Statement;
+  private readonly updateStateStmt: Database.Statement;
+  private readonly insertEventStmt: Database.Statement;
+  private readonly selectEventsByFindingStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+
+    this.insertFindingStmt = this.db.prepare(
+      `INSERT INTO findings
+         (id, engagement_id, canonical_key, node_id, title, severity, confidence,
+          state, state_reason, owner, ticket_ref,
+          first_seen_run_id, last_seen_run_id, first_seen_at, last_seen_at,
+          sla_due_at, attrs_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    this.selectFindingByIdStmt = this.db.prepare(
+      `SELECT id, engagement_id, canonical_key, node_id, title, severity, confidence,
+              state, state_reason, owner, ticket_ref,
+              first_seen_run_id, last_seen_run_id, first_seen_at, last_seen_at,
+              sla_due_at, attrs_json
+       FROM findings WHERE id = ?`,
+    );
+
+    this.deleteFindingStmt = this.db.prepare(`DELETE FROM findings WHERE id = ?`);
+
+    this.updateLastSeenStmt = this.db.prepare(
+      `UPDATE findings
+       SET last_seen_at = ?, last_seen_run_id = ?,
+           title = ?, severity = ?, confidence = ?, attrs_json = ?
+       WHERE id = ?`,
+    );
+
+    this.updateStateStmt = this.db.prepare(
+      `UPDATE findings SET state = ?, state_reason = ? WHERE id = ?`,
+    );
+
+    this.insertEventStmt = this.db.prepare(
+      `INSERT INTO finding_events
+         (id, finding_id, run_id, event_type, before_json, after_json, artifact_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    this.selectEventsByFindingStmt = this.db.prepare(
+      `SELECT id, finding_id, run_id, event_type, before_json, after_json, artifact_id, created_at
+       FROM finding_events
+       WHERE finding_id = ?
+       ORDER BY created_at DESC`,
+    );
+  }
+
+  /**
+   * Finding を upsert する。
+   *
+   * engagement_id + canonical_key が一致する既存レコードがあれば更新（re_observed）、
+   * なければ新規作成（discovered）。いずれの場合も finding_events にイベントを追加する。
+   *
+   * @returns { finding, created } — created は新規作成時 true、既存更新時 false
+   */
+  upsert(input: UpsertFindingInput): { finding: Finding; created: boolean } {
+    const upsertTx = this.db.transaction((inp: UpsertFindingInput) => {
+      const now = new Date().toISOString();
+      const existing = this.db
+        .prepare('SELECT * FROM findings WHERE engagement_id = ? AND canonical_key = ?')
+        .get(inp.engagementId, inp.canonicalKey) as FindingRow | undefined;
+
+      if (existing) {
+        // 既存 Finding を更新
+        this.updateLastSeenStmt.run(
+          now,
+          inp.runId ?? null,
+          inp.title,
+          inp.severity,
+          inp.confidence,
+          inp.attrsJson ?? existing.attrs_json,
+          existing.id,
+        );
+
+        // re_observed イベントを追加
+        this.insertEventStmt.run(
+          crypto.randomUUID(),
+          existing.id,
+          inp.runId ?? null,
+          're_observed',
+          '{}',
+          '{}',
+          null,
+          now,
+        );
+
+        return { finding: this.findById(existing.id)!, created: false };
+      } else {
+        // 新規 Finding を作成
+        const id = crypto.randomUUID();
+        this.insertFindingStmt.run(
+          id,
+          inp.engagementId,
+          inp.canonicalKey,
+          inp.nodeId ?? null,
+          inp.title,
+          inp.severity,
+          inp.confidence,
+          inp.state ?? 'open',
+          null, // state_reason
+          null, // owner
+          null, // ticket_ref
+          inp.runId ?? null, // first_seen_run_id
+          inp.runId ?? null, // last_seen_run_id
+          now, // first_seen_at
+          now, // last_seen_at
+          null, // sla_due_at
+          inp.attrsJson ?? '{}',
+        );
+
+        // discovered イベントを追加
+        this.insertEventStmt.run(
+          crypto.randomUUID(),
+          id,
+          inp.runId ?? null,
+          'discovered',
+          '{}',
+          '{}',
+          null,
+          now,
+        );
+
+        return { finding: this.findById(id)!, created: true };
+      }
+    });
+
+    return upsertTx(input);
+  }
+
+  /**
+   * ID で Finding を取得する。存在しなければ undefined。
+   */
+  findById(id: string): Finding | undefined {
+    const row = this.selectFindingByIdStmt.get(id) as FindingRow | undefined;
+    if (row === undefined) {
+      return undefined;
+    }
+    return rowToFinding(row);
+  }
+
+  /**
+   * エンゲージメント ID で Finding 一覧を取得する。
+   *
+   * opts で state, severity を指定して絞り込み可能。
+   * ORDER BY last_seen_at DESC。
+   */
+  findByEngagement(
+    engagementId: string,
+    opts?: { state?: string; severity?: string },
+  ): Finding[] {
+    const whereClauses: string[] = ['engagement_id = ?'];
+    const params: unknown[] = [engagementId];
+
+    if (opts?.state !== undefined) {
+      whereClauses.push('state = ?');
+      params.push(opts.state);
+    }
+
+    if (opts?.severity !== undefined) {
+      whereClauses.push('severity = ?');
+      params.push(opts.severity);
+    }
+
+    const sql = `SELECT id, engagement_id, canonical_key, node_id, title, severity, confidence,
+                        state, state_reason, owner, ticket_ref,
+                        first_seen_run_id, last_seen_run_id, first_seen_at, last_seen_at,
+                        sla_due_at, attrs_json
+                 FROM findings
+                 WHERE ${whereClauses.join(' AND ')}
+                 ORDER BY last_seen_at DESC`;
+
+    const rows = this.db.prepare(sql).all(...params) as FindingRow[];
+    return rows.map(rowToFinding);
+  }
+
+  /**
+   * Finding の状態を更新する。
+   *
+   * state と state_reason を更新し、'state_change' イベントを自動追加する。
+   * 存在しない ID の場合 undefined を返す。
+   */
+  updateState(id: string, state: string, reason?: string): Finding | undefined {
+    const updateStateTx = this.db.transaction(
+      (findingId: string, newState: string, stateReason?: string) => {
+        // 既存 Finding を取得
+        const existing = this.findById(findingId);
+        if (existing === undefined) {
+          return undefined;
+        }
+
+        const oldState = existing.state;
+
+        // state と state_reason を更新
+        this.updateStateStmt.run(newState, stateReason ?? null, findingId);
+
+        // state_change イベントを追加
+        const now = new Date().toISOString();
+        this.insertEventStmt.run(
+          crypto.randomUUID(),
+          findingId,
+          null, // run_id
+          'state_change',
+          JSON.stringify({ state: oldState }),
+          JSON.stringify({ state: newState }),
+          null, // artifact_id
+          now,
+        );
+
+        return this.findById(findingId);
+      },
+    );
+
+    return updateStateTx(id, state, reason);
+  }
+
+  /**
+   * Finding にイベントを手動追加する。
+   */
+  addEvent(findingId: string, event: CreateFindingEventInput): FindingEvent {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    this.insertEventStmt.run(
+      id,
+      findingId,
+      event.runId ?? null,
+      event.eventType,
+      event.beforeJson ?? '{}',
+      event.afterJson ?? '{}',
+      event.artifactId ?? null,
+      now,
+    );
+
+    return {
+      id,
+      findingId,
+      ...(event.runId !== undefined ? { runId: event.runId } : {}),
+      eventType: event.eventType,
+      beforeJson: event.beforeJson ?? '{}',
+      afterJson: event.afterJson ?? '{}',
+      ...(event.artifactId !== undefined ? { artifactId: event.artifactId } : {}),
+      createdAt: now,
+    };
+  }
+
+  /**
+   * Finding のイベント一覧を取得する。
+   *
+   * ORDER BY created_at DESC（最新が先頭）。
+   */
+  getEvents(findingId: string): FindingEvent[] {
+    const rows = this.selectEventsByFindingStmt.all(findingId) as FindingEventRow[];
+    return rows.map(rowToFindingEvent);
+  }
+
+  /**
+   * Finding を削除する。
+   *
+   * CASCADE により関連する finding_events も同時に削除される。
+   *
+   * @returns 削除成功時 true、id が存在しない場合 false。
+   */
+  delete(id: string): boolean {
+    const result = this.deleteFindingStmt.run(id);
+    return result.changes > 0;
+  }
+}

--- a/src/db/repository/finding-repository.ts
+++ b/src/db/repository/finding-repository.ts
@@ -200,7 +200,11 @@ export class FindingRepository {
           now,
         );
 
-        return { finding: this.findById(existing.id)!, created: false };
+        const updated = this.findById(existing.id);
+        if (updated === undefined) {
+          throw new Error(`Finding ${existing.id} not found after update`);
+        }
+        return { finding: updated, created: false };
       } else {
         // 新規 Finding を作成
         const id = crypto.randomUUID();
@@ -236,7 +240,11 @@ export class FindingRepository {
           now,
         );
 
-        return { finding: this.findById(id)!, created: true };
+        const created = this.findById(id);
+        if (created === undefined) {
+          throw new Error(`Finding ${id} not found after insert`);
+        }
+        return { finding: created, created: true };
       }
     });
 

--- a/src/db/repository/risk-snapshot-repository.ts
+++ b/src/db/repository/risk-snapshot-repository.ts
@@ -1,0 +1,227 @@
+/**
+ * sonobat — RiskSnapshotRepository
+ *
+ * risk_snapshots テーブルに対する CRUD 操作。
+ * エンゲージメントごとのリスクスコア時系列管理を提供する。
+ */
+
+import type Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import type { RiskSnapshot, CreateRiskSnapshotInput } from '../../types/operational.js';
+
+// ---------------------------------------------------------------------------
+// DB row 型
+// ---------------------------------------------------------------------------
+
+/** better-sqlite3 から返る risk_snapshots テーブルの行形状 */
+interface RiskSnapshotRow {
+  id: string;
+  engagement_id: string;
+  run_id: string | null;
+  score: number;
+  open_critical: number;
+  open_high: number;
+  open_medium: number;
+  open_low: number;
+  open_info: number;
+  open_total: number;
+  attack_path_count: number;
+  exposed_cred_count: number;
+  model_version: string | null;
+  attrs_json: string;
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Row → RiskSnapshot 変換
+// ---------------------------------------------------------------------------
+
+/** snake_case DB row を camelCase RiskSnapshot にマッピング */
+function rowToRiskSnapshot(row: RiskSnapshotRow): RiskSnapshot {
+  return {
+    id: row.id,
+    engagementId: row.engagement_id,
+    ...(row.run_id !== null ? { runId: row.run_id } : {}),
+    score: row.score,
+    openCritical: row.open_critical,
+    openHigh: row.open_high,
+    openMedium: row.open_medium,
+    openLow: row.open_low,
+    openInfo: row.open_info,
+    openTotal: row.open_total,
+    attackPathCount: row.attack_path_count,
+    exposedCredCount: row.exposed_cred_count,
+    ...(row.model_version !== null ? { modelVersion: row.model_version } : {}),
+    attrsJson: row.attrs_json,
+    createdAt: row.created_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RiskSnapshotRepository
+// ---------------------------------------------------------------------------
+
+/**
+ * risk_snapshots テーブルの CRUD リポジトリ。
+ *
+ * - デフォルト値: 全 integer フィールドは 0、attrsJson は '{}'、created_at は現在時刻
+ * - ID は crypto.randomUUID() で生成
+ * - findByEngagement() は created_at DESC でソートし、デフォルト limit は 100
+ * - latest() は最新のスナップショットを1件返す
+ */
+export class RiskSnapshotRepository {
+  private readonly db: Database.Database;
+
+  private readonly insertStmt: Database.Statement;
+  private readonly selectByIdStmt: Database.Statement;
+  private readonly selectByEngagementStmt: Database.Statement;
+  private readonly latestStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+
+    this.insertStmt = this.db.prepare(
+      `INSERT INTO risk_snapshots
+         (id, engagement_id, run_id, score,
+          open_critical, open_high, open_medium, open_low, open_info, open_total,
+          attack_path_count, exposed_cred_count, model_version,
+          attrs_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    this.selectByIdStmt = this.db.prepare(
+      `SELECT id, engagement_id, run_id, score,
+              open_critical, open_high, open_medium, open_low, open_info, open_total,
+              attack_path_count, exposed_cred_count, model_version,
+              attrs_json, created_at
+       FROM risk_snapshots WHERE id = ?`,
+    );
+
+    this.selectByEngagementStmt = this.db.prepare(
+      `SELECT id, engagement_id, run_id, score,
+              open_critical, open_high, open_medium, open_low, open_info, open_total,
+              attack_path_count, exposed_cred_count, model_version,
+              attrs_json, created_at
+       FROM risk_snapshots
+       WHERE engagement_id = ?
+       ORDER BY created_at DESC
+       LIMIT ?`,
+    );
+
+    this.latestStmt = this.db.prepare(
+      `SELECT id, engagement_id, run_id, score,
+              open_critical, open_high, open_medium, open_low, open_info, open_total,
+              attack_path_count, exposed_cred_count, model_version,
+              attrs_json, created_at
+       FROM risk_snapshots
+       WHERE engagement_id = ?
+       ORDER BY created_at DESC
+       LIMIT 1`,
+    );
+  }
+
+  /**
+   * RiskSnapshot を新規作成して返す。
+   *
+   * デフォルト値:
+   * - openCritical, openHigh, openMedium, openLow, openInfo, openTotal: 0
+   * - attackPathCount: 0
+   * - exposedCredCount: 0
+   * - attrsJson: '{}'
+   * - createdAt: 現在時刻（ISO 8601）
+   */
+  create(input: CreateRiskSnapshotInput): RiskSnapshot {
+    const id = crypto.randomUUID();
+    const createdAt = new Date().toISOString();
+
+    const runId = input.runId ?? null;
+    const openCritical = input.openCritical ?? 0;
+    const openHigh = input.openHigh ?? 0;
+    const openMedium = input.openMedium ?? 0;
+    const openLow = input.openLow ?? 0;
+    const openInfo = input.openInfo ?? 0;
+    const openTotal = input.openTotal ?? 0;
+    const attackPathCount = input.attackPathCount ?? 0;
+    const exposedCredCount = input.exposedCredCount ?? 0;
+    const modelVersion = input.modelVersion ?? null;
+    const attrsJson = input.attrsJson ?? '{}';
+
+    this.insertStmt.run(
+      id,
+      input.engagementId,
+      runId,
+      input.score,
+      openCritical,
+      openHigh,
+      openMedium,
+      openLow,
+      openInfo,
+      openTotal,
+      attackPathCount,
+      exposedCredCount,
+      modelVersion,
+      attrsJson,
+      createdAt,
+    );
+
+    return {
+      id,
+      engagementId: input.engagementId,
+      ...(runId !== null ? { runId } : {}),
+      score: input.score,
+      openCritical,
+      openHigh,
+      openMedium,
+      openLow,
+      openInfo,
+      openTotal,
+      attackPathCount,
+      exposedCredCount,
+      ...(modelVersion !== null ? { modelVersion } : {}),
+      attrsJson,
+      createdAt,
+    };
+  }
+
+  /**
+   * ID で RiskSnapshot を取得する。存在しなければ undefined。
+   */
+  findById(id: string): RiskSnapshot | undefined {
+    const row = this.selectByIdStmt.get(id) as RiskSnapshotRow | undefined;
+    if (row === undefined) {
+      return undefined;
+    }
+    return rowToRiskSnapshot(row);
+  }
+
+  /**
+   * エンゲージメントに紐づく RiskSnapshot 一覧を取得する。
+   *
+   * created_at DESC でソートし、limit で件数を制限する（デフォルト 100）。
+   *
+   * @param engagementId エンゲージメント ID
+   * @param limit        最大取得件数（デフォルト 100）
+   * @returns RiskSnapshot 一覧（created_at DESC 順）
+   */
+  findByEngagement(engagementId: string, limit?: number): RiskSnapshot[] {
+    const effectiveLimit = limit ?? 100;
+    const rows = this.selectByEngagementStmt.all(engagementId, effectiveLimit) as RiskSnapshotRow[];
+    return rows.map(rowToRiskSnapshot);
+  }
+
+  /**
+   * エンゲージメントの最新 RiskSnapshot を取得する。
+   *
+   * スナップショットが存在しない場合は undefined を返す。
+   *
+   * @param engagementId エンゲージメント ID
+   * @returns 最新の RiskSnapshot、または undefined
+   */
+  latest(engagementId: string): RiskSnapshot | undefined {
+    const row = this.latestStmt.get(engagementId) as RiskSnapshotRow | undefined;
+    if (row === undefined) {
+      return undefined;
+    }
+    return rowToRiskSnapshot(row);
+  }
+}

--- a/src/db/repository/risk-snapshot-repository.ts
+++ b/src/db/repository/risk-snapshot-repository.ts
@@ -104,7 +104,7 @@ export class RiskSnapshotRepository {
               attrs_json, created_at
        FROM risk_snapshots
        WHERE engagement_id = ?
-       ORDER BY created_at DESC
+       ORDER BY created_at DESC, rowid DESC
        LIMIT ?`,
     );
 
@@ -115,7 +115,7 @@ export class RiskSnapshotRepository {
               attrs_json, created_at
        FROM risk_snapshots
        WHERE engagement_id = ?
-       ORDER BY created_at DESC
+       ORDER BY created_at DESC, rowid DESC
        LIMIT 1`,
     );
   }

--- a/src/db/repository/run-repository.ts
+++ b/src/db/repository/run-repository.ts
@@ -1,0 +1,214 @@
+/**
+ * sonobat — RunRepository
+ *
+ * runs テーブルに対する CRUD 操作を提供する。
+ * snake_case (DB) ↔ camelCase (TypeScript) の変換を内部で行う。
+ */
+
+import type Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import type { Run, CreateRunInput } from '../../types/operational.js';
+
+// ---------------------------------------------------------------------------
+// DB row 型
+// ---------------------------------------------------------------------------
+
+/** better-sqlite3 から返る runs テーブルの行形状 */
+interface RunRow {
+  id: string;
+  engagement_id: string;
+  trigger_kind: string;
+  trigger_ref: string | null;
+  status: string;
+  started_at: string | null;
+  finished_at: string | null;
+  summary_json: string;
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Row → Run 変換
+// ---------------------------------------------------------------------------
+
+/** snake_case DB row を camelCase Run にマッピング */
+function rowToRun(row: RunRow): Run {
+  return {
+    id: row.id,
+    engagementId: row.engagement_id,
+    triggerKind: row.trigger_kind,
+    ...(row.trigger_ref !== null ? { triggerRef: row.trigger_ref } : {}),
+    status: row.status,
+    ...(row.started_at !== null ? { startedAt: row.started_at } : {}),
+    ...(row.finished_at !== null ? { finishedAt: row.finished_at } : {}),
+    summaryJson: row.summary_json,
+    createdAt: row.created_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RunRepository
+// ---------------------------------------------------------------------------
+
+/**
+ * runs テーブルの CRUD リポジトリ。
+ *
+ * - ID は crypto.randomUUID() で生成
+ * - created_at / started_at / finished_at は状況に応じて自動設定
+ */
+export class RunRepository {
+  private readonly db: Database.Database;
+
+  private readonly insertStmt: Database.Statement;
+  private readonly selectByIdStmt: Database.Statement;
+  private readonly selectByEngagementStmt: Database.Statement;
+  private readonly selectByStatusStmt: Database.Statement;
+  private readonly deleteStmt: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+
+    this.insertStmt = this.db.prepare(
+      `INSERT INTO runs (id, engagement_id, trigger_kind, trigger_ref, status, started_at, finished_at, summary_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    this.selectByIdStmt = this.db.prepare(
+      `SELECT id, engagement_id, trigger_kind, trigger_ref, status, started_at, finished_at, summary_json, created_at
+       FROM runs WHERE id = ?`,
+    );
+
+    this.selectByEngagementStmt = this.db.prepare(
+      `SELECT id, engagement_id, trigger_kind, trigger_ref, status, started_at, finished_at, summary_json, created_at
+       FROM runs WHERE engagement_id = ? ORDER BY created_at DESC LIMIT ?`,
+    );
+
+    this.selectByStatusStmt = this.db.prepare(
+      `SELECT id, engagement_id, trigger_kind, trigger_ref, status, started_at, finished_at, summary_json, created_at
+       FROM runs WHERE status = ?`,
+    );
+
+    this.deleteStmt = this.db.prepare(`DELETE FROM runs WHERE id = ?`);
+  }
+
+  /**
+   * Run を新規作成して返す。
+   *
+   * - created_at は現在時刻に設定
+   * - status が 'running' の場合、started_at も現在時刻に設定
+   * - summaryJson はデフォルト '{}'
+   */
+  create(input: CreateRunInput): Run {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const startedAt = input.status === 'running' ? now : null;
+
+    this.insertStmt.run(
+      id,
+      input.engagementId,
+      input.triggerKind,
+      input.triggerRef ?? null,
+      input.status,
+      startedAt,
+      null, // finished_at
+      '{}', // summary_json
+      now, // created_at
+    );
+
+    return {
+      id,
+      engagementId: input.engagementId,
+      triggerKind: input.triggerKind,
+      ...(input.triggerRef !== undefined ? { triggerRef: input.triggerRef } : {}),
+      status: input.status,
+      ...(startedAt !== null ? { startedAt } : {}),
+      summaryJson: '{}',
+      createdAt: now,
+    };
+  }
+
+  /**
+   * ID で Run を取得する。存在しなければ undefined。
+   */
+  findById(id: string): Run | undefined {
+    const row = this.selectByIdStmt.get(id) as RunRow | undefined;
+    if (row === undefined) {
+      return undefined;
+    }
+    return rowToRun(row);
+  }
+
+  /**
+   * engagement_id で Run 一覧を取得する。
+   * ORDER BY created_at DESC、LIMIT デフォルト 100。
+   */
+  findByEngagement(engagementId: string, limit?: number): Run[] {
+    const rows = this.selectByEngagementStmt.all(engagementId, limit ?? 100) as RunRow[];
+    return rows.map(rowToRun);
+  }
+
+  /**
+   * status で Run 一覧を取得する。
+   */
+  findByStatus(status: string): Run[] {
+    const rows = this.selectByStatusStmt.all(status) as RunRow[];
+    return rows.map(rowToRun);
+  }
+
+  /**
+   * Run のステータスを更新する。
+   *
+   * - 'succeeded' または 'failed' の場合、finished_at を現在時刻に設定
+   * - 'running' の場合、started_at が未設定なら現在時刻に設定
+   * - summaryJson が指定された場合、summary_json も更新
+   *
+   * @returns 更新後の Run。id が存在しなければ undefined。
+   */
+  updateStatus(id: string, status: string, summaryJson?: string): Run | undefined {
+    // 既存レコードを確認
+    const existing = this.findById(id);
+    if (existing === undefined) {
+      return undefined;
+    }
+
+    const now = new Date().toISOString();
+
+    // 動的に SET 句を構築
+    const setClauses: string[] = ['status = ?'];
+    const params: unknown[] = [status];
+
+    // finished_at: succeeded / failed の場合に設定
+    if (status === 'succeeded' || status === 'failed') {
+      setClauses.push('finished_at = ?');
+      params.push(now);
+    }
+
+    // started_at: running に遷移し、まだ未設定の場合に設定
+    if (status === 'running' && existing.startedAt === undefined) {
+      setClauses.push('started_at = ?');
+      params.push(now);
+    }
+
+    // summaryJson: 指定された場合に更新
+    if (summaryJson !== undefined) {
+      setClauses.push('summary_json = ?');
+      params.push(summaryJson);
+    }
+
+    params.push(id);
+
+    const sql = `UPDATE runs SET ${setClauses.join(', ')} WHERE id = ?`;
+    this.db.prepare(sql).run(...params);
+
+    return this.findById(id);
+  }
+
+  /**
+   * Run を削除する。
+   *
+   * @returns 削除成功時 true、id が存在しない場合 false。
+   */
+  delete(id: string): boolean {
+    const result = this.deleteStmt.run(id);
+    return result.changes > 0;
+  }
+}

--- a/src/db/repository/run-repository.ts
+++ b/src/db/repository/run-repository.ts
@@ -170,6 +170,11 @@ export class RunRepository {
       return undefined;
     }
 
+    // 完了済み Run の二重完了を防止
+    if (existing.status === 'succeeded' || existing.status === 'failed') {
+      return undefined;
+    }
+
     const now = new Date().toISOString();
 
     // 動的に SET 句を構築

--- a/src/engine/git-ops.ts
+++ b/src/engine/git-ops.ts
@@ -54,17 +54,29 @@ function classifyError(err: unknown, operation: 'clone' | 'pull'): GitResult {
 
   const combined = `${errorMessage} ${stderr}`.toLowerCase();
 
-  if (combined.includes('enoent') || combined.includes('not recognized') || combined.includes('not found')) {
+  if (
+    combined.includes('enoent') ||
+    combined.includes('not recognized') ||
+    combined.includes('not found')
+  ) {
     return {
       ok: false,
-      error: { kind: 'git_not_found', message: 'git is not installed or not in PATH', cause: errorMessage },
+      error: {
+        kind: 'git_not_found',
+        message: 'git is not installed or not in PATH',
+        cause: errorMessage,
+      },
     };
   }
 
   if (combined.includes('permission denied') || combined.includes('access denied')) {
     return {
       ok: false,
-      error: { kind: 'permission_denied', message: `Permission denied during ${operation}`, cause: errorMessage },
+      error: {
+        kind: 'permission_denied',
+        message: `Permission denied during ${operation}`,
+        cause: errorMessage,
+      },
     };
   }
 
@@ -76,7 +88,11 @@ function classifyError(err: unknown, operation: 'clone' | 'pull'): GitResult {
   ) {
     return {
       ok: false,
-      error: { kind: 'network_error', message: `Network error during ${operation}`, cause: errorMessage },
+      error: {
+        kind: 'network_error',
+        message: `Network error during ${operation}`,
+        cause: errorMessage,
+      },
     };
   }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -33,8 +33,8 @@ export function createMcpServer(db: Database.Database, version?: string): McpSer
   registerMutateTool(server, db);
   registerIngestTool(server, db);
   registerProposeTool(server, db);
-  registerKbTools(server, db);       // search_kb + index_kb
-  registerOpsTools(server, db);      // ops (engagement/run/action management)
+  registerKbTools(server, db); // search_kb + index_kb
+  registerOpsTools(server, db); // ops (engagement/run/action management)
   registerFindingsTools(server, db); // findings (finding/risk management)
 
   // Register resources

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,6 +11,8 @@ import { registerMutateTool } from './tools/mutate.js';
 import { registerIngestTool } from './tools/ingest.js';
 import { registerProposeTool } from './tools/propose.js';
 import { registerKbTools } from './tools/kb.js';
+import { registerOpsTools } from './tools/ops.js';
+import { registerFindingsTools } from './tools/findings.js';
 import { registerResources } from './resources.js';
 
 /**
@@ -26,12 +28,14 @@ export function createMcpServer(db: Database.Database, version?: string): McpSer
     version: version ?? '0.0.0',
   });
 
-  // Register tools (6 tools total)
+  // Register tools (8 tools total)
   registerQueryTool(server, db);
   registerMutateTool(server, db);
   registerIngestTool(server, db);
   registerProposeTool(server, db);
-  registerKbTools(server, db); // search_kb + index_kb
+  registerKbTools(server, db);       // search_kb + index_kb
+  registerOpsTools(server, db);      // ops (engagement/run/action management)
+  registerFindingsTools(server, db); // findings (finding/risk management)
 
   // Register resources
   registerResources(server, db);

--- a/src/mcp/tools/findings.ts
+++ b/src/mcp/tools/findings.ts
@@ -85,6 +85,7 @@ export function registerFindingsTools(server: McpServer, db: Database.Database):
       modelVersion,
       limit,
     }) => {
+      try {
       switch (action) {
         // ----------------------------------------------------------------
         // Finding actions
@@ -355,6 +356,13 @@ export function registerFindingsTools(server: McpServer, db: Database.Database):
           }
           return { content: [{ type: 'text', text: JSON.stringify(latest, null, 2) }] };
         }
+      }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text', text: `findings error: ${message}` }],
+          isError: true,
+        };
       }
     },
   );

--- a/src/mcp/tools/findings.ts
+++ b/src/mcp/tools/findings.ts
@@ -1,0 +1,361 @@
+/**
+ * sonobat — MCP Findings Tool (unified)
+ *
+ * Single 'findings' tool with an 'action' parameter for managing
+ * findings, finding events, and risk snapshots.
+ *
+ * Actions: upsert_finding, get_finding, list_findings,
+ *   update_finding_state, list_finding_events,
+ *   create_risk_snapshot, get_risk_snapshot,
+ *   list_risk_snapshots, latest_risk_snapshot
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type Database from 'better-sqlite3';
+import { z } from 'zod';
+import { FindingRepository } from '../../db/repository/finding-repository.js';
+import { RiskSnapshotRepository } from '../../db/repository/risk-snapshot-repository.js';
+
+export function registerFindingsTools(server: McpServer, db: Database.Database): void {
+  const findingRepo = new FindingRepository(db);
+  const riskSnapshotRepo = new RiskSnapshotRepository(db);
+
+  server.tool(
+    'findings',
+    'Manage findings and risk snapshots. Actions: upsert_finding, get_finding, list_findings, update_finding_state, list_finding_events, create_risk_snapshot, get_risk_snapshot, list_risk_snapshots, latest_risk_snapshot',
+    {
+      action: z.enum([
+        'upsert_finding',
+        'get_finding',
+        'list_findings',
+        'update_finding_state',
+        'list_finding_events',
+        'create_risk_snapshot',
+        'get_risk_snapshot',
+        'list_risk_snapshots',
+        'latest_risk_snapshot',
+      ]),
+      id: z.string().optional().describe('Entity ID'),
+      engagementId: z.string().optional().describe('Engagement ID'),
+      canonicalKey: z.string().optional().describe('Finding canonical key'),
+      nodeId: z.string().optional().describe('Associated node ID'),
+      title: z.string().optional().describe('Finding title'),
+      severity: z.string().optional().describe('Finding severity'),
+      confidence: z.string().optional().describe('Finding confidence'),
+      state: z.string().optional().describe('Finding state'),
+      stateReason: z.string().optional().describe('Reason for state change'),
+      runId: z.string().optional().describe('Run ID'),
+      findingId: z.string().optional().describe('Finding ID for events'),
+      attrsJson: z.string().optional().describe('Attributes as JSON'),
+      score: z.number().optional().describe('Risk score'),
+      openCritical: z.number().optional().describe('Open critical count'),
+      openHigh: z.number().optional().describe('Open high count'),
+      openMedium: z.number().optional().describe('Open medium count'),
+      openLow: z.number().optional().describe('Open low count'),
+      openInfo: z.number().optional().describe('Open info count'),
+      openTotal: z.number().optional().describe('Open total count'),
+      attackPathCount: z.number().optional().describe('Attack path count'),
+      exposedCredCount: z.number().optional().describe('Exposed credential count'),
+      modelVersion: z.string().optional().describe('Risk model version'),
+      limit: z.number().optional().describe('Result limit'),
+    },
+    async ({
+      action,
+      id,
+      engagementId,
+      canonicalKey,
+      nodeId,
+      title,
+      severity,
+      confidence,
+      state,
+      stateReason,
+      runId,
+      findingId,
+      attrsJson,
+      score,
+      openCritical,
+      openHigh,
+      openMedium,
+      openLow,
+      openInfo,
+      openTotal,
+      attackPathCount,
+      exposedCredCount,
+      modelVersion,
+      limit,
+    }) => {
+      switch (action) {
+        // ----------------------------------------------------------------
+        // Finding actions
+        // ----------------------------------------------------------------
+        case 'upsert_finding': {
+          if (!engagementId) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'engagementId parameter is required for upsert_finding',
+                },
+              ],
+              isError: true,
+            };
+          }
+          if (!canonicalKey) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'canonicalKey parameter is required for upsert_finding',
+                },
+              ],
+              isError: true,
+            };
+          }
+          if (!title) {
+            return {
+              content: [
+                { type: 'text', text: 'title parameter is required for upsert_finding' },
+              ],
+              isError: true,
+            };
+          }
+          if (!severity) {
+            return {
+              content: [
+                { type: 'text', text: 'severity parameter is required for upsert_finding' },
+              ],
+              isError: true,
+            };
+          }
+          if (!confidence) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'confidence parameter is required for upsert_finding',
+                },
+              ],
+              isError: true,
+            };
+          }
+          const result = findingRepo.upsert({
+            engagementId,
+            canonicalKey,
+            title,
+            severity,
+            confidence,
+            nodeId,
+            state,
+            runId,
+            attrsJson,
+          });
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ ...result.finding, created: result.created }, null, 2),
+              },
+            ],
+          };
+        }
+
+        case 'get_finding': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for get_finding' },
+              ],
+              isError: true,
+            };
+          }
+          const finding = findingRepo.findById(id);
+          if (!finding) {
+            return {
+              content: [{ type: 'text', text: `Finding not found: ${id}` }],
+              isError: true,
+            };
+          }
+          return { content: [{ type: 'text', text: JSON.stringify(finding, null, 2) }] };
+        }
+
+        case 'list_findings': {
+          if (!engagementId) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'engagementId parameter is required for list_findings',
+                },
+              ],
+              isError: true,
+            };
+          }
+          const opts: { state?: string; severity?: string } = {};
+          if (state) opts.state = state;
+          if (severity) opts.severity = severity;
+          const findings = findingRepo.findByEngagement(engagementId, opts);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(findings, null, 2) }],
+          };
+        }
+
+        case 'update_finding_state': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for update_finding_state' },
+              ],
+              isError: true,
+            };
+          }
+          if (!state) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'state parameter is required for update_finding_state',
+                },
+              ],
+              isError: true,
+            };
+          }
+          const updated = findingRepo.updateState(id, state, stateReason);
+          if (!updated) {
+            return {
+              content: [{ type: 'text', text: `Finding not found: ${id}` }],
+              isError: true,
+            };
+          }
+          return { content: [{ type: 'text', text: JSON.stringify(updated, null, 2) }] };
+        }
+
+        case 'list_finding_events': {
+          if (!findingId) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'findingId parameter is required for list_finding_events',
+                },
+              ],
+              isError: true,
+            };
+          }
+          const events = findingRepo.getEvents(findingId);
+          return { content: [{ type: 'text', text: JSON.stringify(events, null, 2) }] };
+        }
+
+        // ----------------------------------------------------------------
+        // RiskSnapshot actions
+        // ----------------------------------------------------------------
+        case 'create_risk_snapshot': {
+          if (!engagementId) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'engagementId parameter is required for create_risk_snapshot',
+                },
+              ],
+              isError: true,
+            };
+          }
+          if (score === undefined || score === null) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'score parameter is required for create_risk_snapshot',
+                },
+              ],
+              isError: true,
+            };
+          }
+          const snapshot = riskSnapshotRepo.create({
+            engagementId,
+            score,
+            runId,
+            openCritical,
+            openHigh,
+            openMedium,
+            openLow,
+            openInfo,
+            openTotal,
+            attackPathCount,
+            exposedCredCount,
+            modelVersion,
+            attrsJson,
+          });
+          return {
+            content: [{ type: 'text', text: JSON.stringify(snapshot, null, 2) }],
+          };
+        }
+
+        case 'get_risk_snapshot': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for get_risk_snapshot' },
+              ],
+              isError: true,
+            };
+          }
+          const snapshot = riskSnapshotRepo.findById(id);
+          if (!snapshot) {
+            return {
+              content: [{ type: 'text', text: `Risk snapshot not found: ${id}` }],
+              isError: true,
+            };
+          }
+          return { content: [{ type: 'text', text: JSON.stringify(snapshot, null, 2) }] };
+        }
+
+        case 'list_risk_snapshots': {
+          if (!engagementId) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'engagementId parameter is required for list_risk_snapshots',
+                },
+              ],
+              isError: true,
+            };
+          }
+          const snapshots = riskSnapshotRepo.findByEngagement(engagementId, limit);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(snapshots, null, 2) }],
+          };
+        }
+
+        case 'latest_risk_snapshot': {
+          if (!engagementId) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'engagementId parameter is required for latest_risk_snapshot',
+                },
+              ],
+              isError: true,
+            };
+          }
+          const latest = riskSnapshotRepo.latest(engagementId);
+          if (!latest) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `No risk snapshot found for engagement: ${engagementId}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          return { content: [{ type: 'text', text: JSON.stringify(latest, null, 2) }] };
+        }
+      }
+    },
+  );
+}

--- a/src/mcp/tools/findings.ts
+++ b/src/mcp/tools/findings.ts
@@ -86,277 +86,271 @@ export function registerFindingsTools(server: McpServer, db: Database.Database):
       limit,
     }) => {
       try {
-      switch (action) {
-        // ----------------------------------------------------------------
-        // Finding actions
-        // ----------------------------------------------------------------
-        case 'upsert_finding': {
-          if (!engagementId) {
+        switch (action) {
+          // ----------------------------------------------------------------
+          // Finding actions
+          // ----------------------------------------------------------------
+          case 'upsert_finding': {
+            if (!engagementId) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'engagementId parameter is required for upsert_finding',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            if (!canonicalKey) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'canonicalKey parameter is required for upsert_finding',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            if (!title) {
+              return {
+                content: [{ type: 'text', text: 'title parameter is required for upsert_finding' }],
+                isError: true,
+              };
+            }
+            if (!severity) {
+              return {
+                content: [
+                  { type: 'text', text: 'severity parameter is required for upsert_finding' },
+                ],
+                isError: true,
+              };
+            }
+            if (!confidence) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'confidence parameter is required for upsert_finding',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const result = findingRepo.upsert({
+              engagementId,
+              canonicalKey,
+              title,
+              severity,
+              confidence,
+              nodeId,
+              state,
+              runId,
+              attrsJson,
+            });
             return {
               content: [
                 {
                   type: 'text',
-                  text: 'engagementId parameter is required for upsert_finding',
+                  text: JSON.stringify({ ...result.finding, created: result.created }, null, 2),
                 },
               ],
-              isError: true,
             };
           }
-          if (!canonicalKey) {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'canonicalKey parameter is required for upsert_finding',
-                },
-              ],
-              isError: true,
-            };
-          }
-          if (!title) {
-            return {
-              content: [
-                { type: 'text', text: 'title parameter is required for upsert_finding' },
-              ],
-              isError: true,
-            };
-          }
-          if (!severity) {
-            return {
-              content: [
-                { type: 'text', text: 'severity parameter is required for upsert_finding' },
-              ],
-              isError: true,
-            };
-          }
-          if (!confidence) {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'confidence parameter is required for upsert_finding',
-                },
-              ],
-              isError: true,
-            };
-          }
-          const result = findingRepo.upsert({
-            engagementId,
-            canonicalKey,
-            title,
-            severity,
-            confidence,
-            nodeId,
-            state,
-            runId,
-            attrsJson,
-          });
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({ ...result.finding, created: result.created }, null, 2),
-              },
-            ],
-          };
-        }
 
-        case 'get_finding': {
-          if (!id) {
-            return {
-              content: [
-                { type: 'text', text: 'id parameter is required for get_finding' },
-              ],
-              isError: true,
-            };
+          case 'get_finding': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for get_finding' }],
+                isError: true,
+              };
+            }
+            const finding = findingRepo.findById(id);
+            if (!finding) {
+              return {
+                content: [{ type: 'text', text: `Finding not found: ${id}` }],
+                isError: true,
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(finding, null, 2) }] };
           }
-          const finding = findingRepo.findById(id);
-          if (!finding) {
-            return {
-              content: [{ type: 'text', text: `Finding not found: ${id}` }],
-              isError: true,
-            };
-          }
-          return { content: [{ type: 'text', text: JSON.stringify(finding, null, 2) }] };
-        }
 
-        case 'list_findings': {
-          if (!engagementId) {
+          case 'list_findings': {
+            if (!engagementId) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'engagementId parameter is required for list_findings',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const opts: { state?: string; severity?: string } = {};
+            if (state) opts.state = state;
+            if (severity) opts.severity = severity;
+            const findings = findingRepo.findByEngagement(engagementId, opts);
             return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'engagementId parameter is required for list_findings',
-                },
-              ],
-              isError: true,
+              content: [{ type: 'text', text: JSON.stringify(findings, null, 2) }],
             };
           }
-          const opts: { state?: string; severity?: string } = {};
-          if (state) opts.state = state;
-          if (severity) opts.severity = severity;
-          const findings = findingRepo.findByEngagement(engagementId, opts);
-          return {
-            content: [{ type: 'text', text: JSON.stringify(findings, null, 2) }],
-          };
-        }
 
-        case 'update_finding_state': {
-          if (!id) {
-            return {
-              content: [
-                { type: 'text', text: 'id parameter is required for update_finding_state' },
-              ],
-              isError: true,
-            };
+          case 'update_finding_state': {
+            if (!id) {
+              return {
+                content: [
+                  { type: 'text', text: 'id parameter is required for update_finding_state' },
+                ],
+                isError: true,
+              };
+            }
+            if (!state) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'state parameter is required for update_finding_state',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const updated = findingRepo.updateState(id, state, stateReason);
+            if (!updated) {
+              return {
+                content: [{ type: 'text', text: `Finding not found: ${id}` }],
+                isError: true,
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(updated, null, 2) }] };
           }
-          if (!state) {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'state parameter is required for update_finding_state',
-                },
-              ],
-              isError: true,
-            };
-          }
-          const updated = findingRepo.updateState(id, state, stateReason);
-          if (!updated) {
-            return {
-              content: [{ type: 'text', text: `Finding not found: ${id}` }],
-              isError: true,
-            };
-          }
-          return { content: [{ type: 'text', text: JSON.stringify(updated, null, 2) }] };
-        }
 
-        case 'list_finding_events': {
-          if (!findingId) {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'findingId parameter is required for list_finding_events',
-                },
-              ],
-              isError: true,
-            };
+          case 'list_finding_events': {
+            if (!findingId) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'findingId parameter is required for list_finding_events',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const events = findingRepo.getEvents(findingId);
+            return { content: [{ type: 'text', text: JSON.stringify(events, null, 2) }] };
           }
-          const events = findingRepo.getEvents(findingId);
-          return { content: [{ type: 'text', text: JSON.stringify(events, null, 2) }] };
-        }
 
-        // ----------------------------------------------------------------
-        // RiskSnapshot actions
-        // ----------------------------------------------------------------
-        case 'create_risk_snapshot': {
-          if (!engagementId) {
+          // ----------------------------------------------------------------
+          // RiskSnapshot actions
+          // ----------------------------------------------------------------
+          case 'create_risk_snapshot': {
+            if (!engagementId) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'engagementId parameter is required for create_risk_snapshot',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            if (score === undefined || score === null) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'score parameter is required for create_risk_snapshot',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const snapshot = riskSnapshotRepo.create({
+              engagementId,
+              score,
+              runId,
+              openCritical,
+              openHigh,
+              openMedium,
+              openLow,
+              openInfo,
+              openTotal,
+              attackPathCount,
+              exposedCredCount,
+              modelVersion,
+              attrsJson,
+            });
             return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'engagementId parameter is required for create_risk_snapshot',
-                },
-              ],
-              isError: true,
+              content: [{ type: 'text', text: JSON.stringify(snapshot, null, 2) }],
             };
           }
-          if (score === undefined || score === null) {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'score parameter is required for create_risk_snapshot',
-                },
-              ],
-              isError: true,
-            };
-          }
-          const snapshot = riskSnapshotRepo.create({
-            engagementId,
-            score,
-            runId,
-            openCritical,
-            openHigh,
-            openMedium,
-            openLow,
-            openInfo,
-            openTotal,
-            attackPathCount,
-            exposedCredCount,
-            modelVersion,
-            attrsJson,
-          });
-          return {
-            content: [{ type: 'text', text: JSON.stringify(snapshot, null, 2) }],
-          };
-        }
 
-        case 'get_risk_snapshot': {
-          if (!id) {
-            return {
-              content: [
-                { type: 'text', text: 'id parameter is required for get_risk_snapshot' },
-              ],
-              isError: true,
-            };
+          case 'get_risk_snapshot': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for get_risk_snapshot' }],
+                isError: true,
+              };
+            }
+            const snapshot = riskSnapshotRepo.findById(id);
+            if (!snapshot) {
+              return {
+                content: [{ type: 'text', text: `Risk snapshot not found: ${id}` }],
+                isError: true,
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(snapshot, null, 2) }] };
           }
-          const snapshot = riskSnapshotRepo.findById(id);
-          if (!snapshot) {
-            return {
-              content: [{ type: 'text', text: `Risk snapshot not found: ${id}` }],
-              isError: true,
-            };
-          }
-          return { content: [{ type: 'text', text: JSON.stringify(snapshot, null, 2) }] };
-        }
 
-        case 'list_risk_snapshots': {
-          if (!engagementId) {
+          case 'list_risk_snapshots': {
+            if (!engagementId) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'engagementId parameter is required for list_risk_snapshots',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const snapshots = riskSnapshotRepo.findByEngagement(engagementId, limit);
             return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'engagementId parameter is required for list_risk_snapshots',
-                },
-              ],
-              isError: true,
+              content: [{ type: 'text', text: JSON.stringify(snapshots, null, 2) }],
             };
           }
-          const snapshots = riskSnapshotRepo.findByEngagement(engagementId, limit);
-          return {
-            content: [{ type: 'text', text: JSON.stringify(snapshots, null, 2) }],
-          };
-        }
 
-        case 'latest_risk_snapshot': {
-          if (!engagementId) {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'engagementId parameter is required for latest_risk_snapshot',
-                },
-              ],
-              isError: true,
-            };
+          case 'latest_risk_snapshot': {
+            if (!engagementId) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'engagementId parameter is required for latest_risk_snapshot',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const latest = riskSnapshotRepo.latest(engagementId);
+            if (!latest) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: `No risk snapshot found for engagement: ${engagementId}`,
+                  },
+                ],
+                isError: true,
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(latest, null, 2) }] };
           }
-          const latest = riskSnapshotRepo.latest(engagementId);
-          if (!latest) {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: `No risk snapshot found for engagement: ${engagementId}`,
-                },
-              ],
-              isError: true,
-            };
-          }
-          return { content: [{ type: 'text', text: JSON.stringify(latest, null, 2) }] };
         }
-      }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return {

--- a/src/mcp/tools/ops.ts
+++ b/src/mcp/tools/ops.ts
@@ -1,0 +1,500 @@
+/**
+ * sonobat — MCP Ops Tool (unified)
+ *
+ * Single 'ops' tool with an 'action' parameter for managing
+ * engagements, runs, action queue, and action executions.
+ *
+ * Actions: create_engagement, list_engagements, get_engagement,
+ *   update_engagement, delete_engagement, create_run, list_runs,
+ *   get_run, update_run_status, enqueue_action, poll_action,
+ *   complete_action, fail_action, cancel_action, list_actions,
+ *   get_execution, list_executions
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type Database from 'better-sqlite3';
+import { z } from 'zod';
+import { EngagementRepository } from '../../db/repository/engagement-repository.js';
+import { RunRepository } from '../../db/repository/run-repository.js';
+import { ActionQueueRepository } from '../../db/repository/action-queue-repository.js';
+import { ActionExecutionRepository } from '../../db/repository/action-execution-repository.js';
+
+export function registerOpsTools(server: McpServer, db: Database.Database): void {
+  const engagementRepo = new EngagementRepository(db);
+  const runRepo = new RunRepository(db);
+  const actionQueueRepo = new ActionQueueRepository(db);
+  const actionExecRepo = new ActionExecutionRepository(db);
+
+  server.tool(
+    'ops',
+    'Manage operational entities. Actions: create_engagement, list_engagements, get_engagement, update_engagement, delete_engagement, create_run, list_runs, get_run, update_run_status, enqueue_action, poll_action, complete_action, fail_action, cancel_action, list_actions, get_execution, list_executions',
+    {
+      action: z.enum([
+        'create_engagement',
+        'list_engagements',
+        'get_engagement',
+        'update_engagement',
+        'delete_engagement',
+        'create_run',
+        'list_runs',
+        'get_run',
+        'update_run_status',
+        'enqueue_action',
+        'poll_action',
+        'complete_action',
+        'fail_action',
+        'cancel_action',
+        'list_actions',
+        'get_execution',
+        'list_executions',
+      ]),
+      id: z.string().optional().describe('Entity ID'),
+      engagementId: z.string().optional().describe('Engagement ID'),
+      runId: z.string().optional().describe('Run ID'),
+      actionId: z.string().optional().describe('Action queue item ID'),
+      name: z.string().optional().describe('Engagement name'),
+      environment: z.string().optional().describe('Environment (e.g. stg, prod)'),
+      status: z.string().optional().describe('Status value'),
+      triggerKind: z.string().optional().describe('Run trigger kind'),
+      triggerRef: z.string().optional().describe('Run trigger reference'),
+      kind: z.string().optional().describe('Action kind'),
+      dedupeKey: z.string().optional().describe('Action deduplication key'),
+      leaseOwner: z.string().optional().describe('Lease owner for poll'),
+      executor: z.string().optional().describe('Executor name'),
+      errorMessage: z.string().optional().describe('Error message for fail'),
+      scopeJson: z.string().optional().describe('Scope as JSON'),
+      policyJson: z.string().optional().describe('Policy as JSON'),
+      scheduleCron: z.string().optional().describe('Schedule cron expression'),
+      paramsJson: z.string().optional().describe('Action parameters as JSON'),
+      summaryJson: z.string().optional().describe('Run summary as JSON'),
+      inputJson: z.string().optional().describe('Execution input as JSON'),
+      priority: z.number().optional().describe('Action priority (lower = higher)'),
+      maxAttempts: z.number().optional().describe('Max retry attempts'),
+      leaseDurationSec: z.number().optional().describe('Lease duration in seconds'),
+      limit: z.number().optional().describe('Result limit'),
+      state: z.string().optional().describe('Action state filter'),
+      parentActionId: z.string().optional().describe('Parent action ID'),
+      availableAt: z.string().optional().describe('Available at timestamp'),
+    },
+    async ({
+      action,
+      id,
+      engagementId,
+      runId,
+      actionId,
+      name,
+      environment,
+      status,
+      triggerKind,
+      triggerRef,
+      kind,
+      dedupeKey,
+      leaseOwner,
+      errorMessage,
+      scopeJson,
+      policyJson,
+      scheduleCron,
+      paramsJson,
+      summaryJson,
+      priority,
+      maxAttempts,
+      leaseDurationSec,
+      limit,
+      state,
+      parentActionId,
+      availableAt,
+    }) => {
+      switch (action) {
+        // ----------------------------------------------------------------
+        // Engagement actions
+        // ----------------------------------------------------------------
+        case 'create_engagement': {
+          if (!name) {
+            return {
+              content: [
+                { type: 'text', text: 'name parameter is required for create_engagement' },
+              ],
+              isError: true,
+            };
+          }
+          const engagement = engagementRepo.create({
+            name,
+            environment,
+            scopeJson,
+            policyJson,
+            scheduleCron,
+            status,
+          });
+          return { content: [{ type: 'text', text: JSON.stringify(engagement, null, 2) }] };
+        }
+
+        case 'list_engagements': {
+          const engagements = status
+            ? engagementRepo.findByStatus(status)
+            : engagementRepo.list();
+          return { content: [{ type: 'text', text: JSON.stringify(engagements, null, 2) }] };
+        }
+
+        case 'get_engagement': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for get_engagement' },
+              ],
+              isError: true,
+            };
+          }
+          const engagement = engagementRepo.findById(id);
+          if (!engagement) {
+            return {
+              content: [{ type: 'text', text: `Engagement not found: ${id}` }],
+              isError: true,
+            };
+          }
+          return { content: [{ type: 'text', text: JSON.stringify(engagement, null, 2) }] };
+        }
+
+        case 'update_engagement': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for update_engagement' },
+              ],
+              isError: true,
+            };
+          }
+          const fields: Record<string, unknown> = {};
+          if (name !== undefined) fields.name = name;
+          if (environment !== undefined) fields.environment = environment;
+          if (scopeJson !== undefined) fields.scopeJson = scopeJson;
+          if (policyJson !== undefined) fields.policyJson = policyJson;
+          if (scheduleCron !== undefined) fields.scheduleCron = scheduleCron;
+          if (status !== undefined) fields.status = status;
+
+          const updated = engagementRepo.update(id, fields);
+          if (!updated) {
+            return {
+              content: [{ type: 'text', text: `Engagement not found: ${id}` }],
+              isError: true,
+            };
+          }
+          return { content: [{ type: 'text', text: JSON.stringify(updated, null, 2) }] };
+        }
+
+        case 'delete_engagement': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for delete_engagement' },
+              ],
+              isError: true,
+            };
+          }
+          const deleted = engagementRepo.delete(id);
+          if (!deleted) {
+            return {
+              content: [{ type: 'text', text: `Engagement not found: ${id}` }],
+              isError: true,
+            };
+          }
+          return {
+            content: [{ type: 'text', text: `Engagement ${id} deleted successfully.` }],
+          };
+        }
+
+        // ----------------------------------------------------------------
+        // Run actions
+        // ----------------------------------------------------------------
+        case 'create_run': {
+          if (!engagementId) {
+            return {
+              content: [
+                { type: 'text', text: 'engagementId parameter is required for create_run' },
+              ],
+              isError: true,
+            };
+          }
+          if (!triggerKind) {
+            return {
+              content: [
+                { type: 'text', text: 'triggerKind parameter is required for create_run' },
+              ],
+              isError: true,
+            };
+          }
+          if (!status) {
+            return {
+              content: [
+                { type: 'text', text: 'status parameter is required for create_run' },
+              ],
+              isError: true,
+            };
+          }
+          const run = runRepo.create({
+            engagementId,
+            triggerKind,
+            triggerRef,
+            status,
+          });
+          return { content: [{ type: 'text', text: JSON.stringify(run, null, 2) }] };
+        }
+
+        case 'list_runs': {
+          if (!engagementId) {
+            return {
+              content: [
+                { type: 'text', text: 'engagementId parameter is required for list_runs' },
+              ],
+              isError: true,
+            };
+          }
+          const runs = runRepo.findByEngagement(engagementId, limit);
+          return { content: [{ type: 'text', text: JSON.stringify(runs, null, 2) }] };
+        }
+
+        case 'get_run': {
+          if (!id) {
+            return {
+              content: [{ type: 'text', text: 'id parameter is required for get_run' }],
+              isError: true,
+            };
+          }
+          const run = runRepo.findById(id);
+          if (!run) {
+            return {
+              content: [{ type: 'text', text: `Run not found: ${id}` }],
+              isError: true,
+            };
+          }
+          return { content: [{ type: 'text', text: JSON.stringify(run, null, 2) }] };
+        }
+
+        case 'update_run_status': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for update_run_status' },
+              ],
+              isError: true,
+            };
+          }
+          if (!status) {
+            return {
+              content: [
+                { type: 'text', text: 'status parameter is required for update_run_status' },
+              ],
+              isError: true,
+            };
+          }
+          const updatedRun = runRepo.updateStatus(id, status, summaryJson);
+          if (!updatedRun) {
+            return {
+              content: [{ type: 'text', text: `Run not found: ${id}` }],
+              isError: true,
+            };
+          }
+          return { content: [{ type: 'text', text: JSON.stringify(updatedRun, null, 2) }] };
+        }
+
+        // ----------------------------------------------------------------
+        // ActionQueue actions
+        // ----------------------------------------------------------------
+        case 'enqueue_action': {
+          if (!engagementId) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'engagementId parameter is required for enqueue_action',
+                },
+              ],
+              isError: true,
+            };
+          }
+          if (!kind) {
+            return {
+              content: [
+                { type: 'text', text: 'kind parameter is required for enqueue_action' },
+              ],
+              isError: true,
+            };
+          }
+          if (!dedupeKey) {
+            return {
+              content: [
+                { type: 'text', text: 'dedupeKey parameter is required for enqueue_action' },
+              ],
+              isError: true,
+            };
+          }
+          const item = actionQueueRepo.enqueue({
+            engagementId,
+            runId,
+            parentActionId,
+            kind,
+            priority,
+            dedupeKey,
+            paramsJson,
+            state,
+            maxAttempts,
+            availableAt,
+          });
+          return { content: [{ type: 'text', text: JSON.stringify(item, null, 2) }] };
+        }
+
+        case 'poll_action': {
+          if (!leaseOwner) {
+            return {
+              content: [
+                { type: 'text', text: 'leaseOwner parameter is required for poll_action' },
+              ],
+              isError: true,
+            };
+          }
+          const polled = actionQueueRepo.poll(leaseOwner, leaseDurationSec);
+          if (!polled) {
+            return {
+              content: [{ type: 'text', text: 'No action available to poll' }],
+            };
+          }
+          return { content: [{ type: 'text', text: JSON.stringify(polled, null, 2) }] };
+        }
+
+        case 'complete_action': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for complete_action' },
+              ],
+              isError: true,
+            };
+          }
+          const completed = actionQueueRepo.complete(id);
+          if (!completed) {
+            return {
+              content: [
+                { type: 'text', text: `Action not found or not in running state: ${id}` },
+              ],
+              isError: true,
+            };
+          }
+          return {
+            content: [{ type: 'text', text: `Action ${id} completed successfully.` }],
+          };
+        }
+
+        case 'fail_action': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for fail_action' },
+              ],
+              isError: true,
+            };
+          }
+          if (!errorMessage) {
+            return {
+              content: [
+                { type: 'text', text: 'errorMessage parameter is required for fail_action' },
+              ],
+              isError: true,
+            };
+          }
+          const failed = actionQueueRepo.fail(id, errorMessage);
+          if (!failed) {
+            return {
+              content: [
+                { type: 'text', text: `Action not found or not in running state: ${id}` },
+              ],
+              isError: true,
+            };
+          }
+          const afterFail = actionQueueRepo.findById(id);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(afterFail, null, 2) }],
+          };
+        }
+
+        case 'cancel_action': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for cancel_action' },
+              ],
+              isError: true,
+            };
+          }
+          const cancelled = actionQueueRepo.cancel(id);
+          if (!cancelled) {
+            return {
+              content: [{ type: 'text', text: `Action not found: ${id}` }],
+              isError: true,
+            };
+          }
+          return {
+            content: [{ type: 'text', text: `Action ${id} cancelled successfully.` }],
+          };
+        }
+
+        case 'list_actions': {
+          if (!engagementId) {
+            return {
+              content: [
+                { type: 'text', text: 'engagementId parameter is required for list_actions' },
+              ],
+              isError: true,
+            };
+          }
+          const actions = actionQueueRepo.findByEngagement(engagementId, state);
+          return { content: [{ type: 'text', text: JSON.stringify(actions, null, 2) }] };
+        }
+
+        // ----------------------------------------------------------------
+        // ActionExecution actions
+        // ----------------------------------------------------------------
+        case 'get_execution': {
+          if (!id) {
+            return {
+              content: [
+                { type: 'text', text: 'id parameter is required for get_execution' },
+              ],
+              isError: true,
+            };
+          }
+          const execution = actionExecRepo.findById(id);
+          if (!execution) {
+            return {
+              content: [{ type: 'text', text: `Execution not found: ${id}` }],
+              isError: true,
+            };
+          }
+          return { content: [{ type: 'text', text: JSON.stringify(execution, null, 2) }] };
+        }
+
+        case 'list_executions': {
+          if (actionId) {
+            const executions = actionExecRepo.findByAction(actionId);
+            return {
+              content: [{ type: 'text', text: JSON.stringify(executions, null, 2) }],
+            };
+          }
+          if (runId) {
+            const executions = actionExecRepo.findByRun(runId);
+            return {
+              content: [{ type: 'text', text: JSON.stringify(executions, null, 2) }],
+            };
+          }
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'actionId or runId parameter is required for list_executions',
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+    },
+  );
+}

--- a/src/mcp/tools/ops.ts
+++ b/src/mcp/tools/ops.ts
@@ -60,14 +60,12 @@ export function registerOpsTools(server: McpServer, db: Database.Database): void
       kind: z.string().optional().describe('Action kind'),
       dedupeKey: z.string().optional().describe('Action deduplication key'),
       leaseOwner: z.string().optional().describe('Lease owner for poll'),
-      executor: z.string().optional().describe('Executor name'),
       errorMessage: z.string().optional().describe('Error message for fail'),
       scopeJson: z.string().optional().describe('Scope as JSON'),
       policyJson: z.string().optional().describe('Policy as JSON'),
       scheduleCron: z.string().optional().describe('Schedule cron expression'),
       paramsJson: z.string().optional().describe('Action parameters as JSON'),
       summaryJson: z.string().optional().describe('Run summary as JSON'),
-      inputJson: z.string().optional().describe('Execution input as JSON'),
       priority: z.number().optional().describe('Action priority (lower = higher)'),
       maxAttempts: z.number().optional().describe('Max retry attempts'),
       leaseDurationSec: z.number().optional().describe('Lease duration in seconds'),
@@ -104,6 +102,7 @@ export function registerOpsTools(server: McpServer, db: Database.Database): void
       parentActionId,
       availableAt,
     }) => {
+      try {
       switch (action) {
         // ----------------------------------------------------------------
         // Engagement actions
@@ -494,6 +493,13 @@ export function registerOpsTools(server: McpServer, db: Database.Database): void
             isError: true,
           };
         }
+      }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text', text: `ops error: ${message}` }],
+          isError: true,
+        };
       }
     },
   );

--- a/src/mcp/tools/ops.ts
+++ b/src/mcp/tools/ops.ts
@@ -103,397 +103,377 @@ export function registerOpsTools(server: McpServer, db: Database.Database): void
       availableAt,
     }) => {
       try {
-      switch (action) {
-        // ----------------------------------------------------------------
-        // Engagement actions
-        // ----------------------------------------------------------------
-        case 'create_engagement': {
-          if (!name) {
-            return {
-              content: [
-                { type: 'text', text: 'name parameter is required for create_engagement' },
-              ],
-              isError: true,
-            };
+        switch (action) {
+          // ----------------------------------------------------------------
+          // Engagement actions
+          // ----------------------------------------------------------------
+          case 'create_engagement': {
+            if (!name) {
+              return {
+                content: [
+                  { type: 'text', text: 'name parameter is required for create_engagement' },
+                ],
+                isError: true,
+              };
+            }
+            const engagement = engagementRepo.create({
+              name,
+              environment,
+              scopeJson,
+              policyJson,
+              scheduleCron,
+              status,
+            });
+            return { content: [{ type: 'text', text: JSON.stringify(engagement, null, 2) }] };
           }
-          const engagement = engagementRepo.create({
-            name,
-            environment,
-            scopeJson,
-            policyJson,
-            scheduleCron,
-            status,
-          });
-          return { content: [{ type: 'text', text: JSON.stringify(engagement, null, 2) }] };
-        }
 
-        case 'list_engagements': {
-          const engagements = status
-            ? engagementRepo.findByStatus(status)
-            : engagementRepo.list();
-          return { content: [{ type: 'text', text: JSON.stringify(engagements, null, 2) }] };
-        }
+          case 'list_engagements': {
+            const engagements = status
+              ? engagementRepo.findByStatus(status)
+              : engagementRepo.list();
+            return { content: [{ type: 'text', text: JSON.stringify(engagements, null, 2) }] };
+          }
 
-        case 'get_engagement': {
-          if (!id) {
-            return {
-              content: [
-                { type: 'text', text: 'id parameter is required for get_engagement' },
-              ],
-              isError: true,
-            };
+          case 'get_engagement': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for get_engagement' }],
+                isError: true,
+              };
+            }
+            const engagement = engagementRepo.findById(id);
+            if (!engagement) {
+              return {
+                content: [{ type: 'text', text: `Engagement not found: ${id}` }],
+                isError: true,
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(engagement, null, 2) }] };
           }
-          const engagement = engagementRepo.findById(id);
-          if (!engagement) {
-            return {
-              content: [{ type: 'text', text: `Engagement not found: ${id}` }],
-              isError: true,
-            };
-          }
-          return { content: [{ type: 'text', text: JSON.stringify(engagement, null, 2) }] };
-        }
 
-        case 'update_engagement': {
-          if (!id) {
-            return {
-              content: [
-                { type: 'text', text: 'id parameter is required for update_engagement' },
-              ],
-              isError: true,
-            };
-          }
-          const fields: Record<string, unknown> = {};
-          if (name !== undefined) fields.name = name;
-          if (environment !== undefined) fields.environment = environment;
-          if (scopeJson !== undefined) fields.scopeJson = scopeJson;
-          if (policyJson !== undefined) fields.policyJson = policyJson;
-          if (scheduleCron !== undefined) fields.scheduleCron = scheduleCron;
-          if (status !== undefined) fields.status = status;
+          case 'update_engagement': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for update_engagement' }],
+                isError: true,
+              };
+            }
+            const fields: Record<string, unknown> = {};
+            if (name !== undefined) fields.name = name;
+            if (environment !== undefined) fields.environment = environment;
+            if (scopeJson !== undefined) fields.scopeJson = scopeJson;
+            if (policyJson !== undefined) fields.policyJson = policyJson;
+            if (scheduleCron !== undefined) fields.scheduleCron = scheduleCron;
+            if (status !== undefined) fields.status = status;
 
-          const updated = engagementRepo.update(id, fields);
-          if (!updated) {
-            return {
-              content: [{ type: 'text', text: `Engagement not found: ${id}` }],
-              isError: true,
-            };
+            const updated = engagementRepo.update(id, fields);
+            if (!updated) {
+              return {
+                content: [{ type: 'text', text: `Engagement not found: ${id}` }],
+                isError: true,
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(updated, null, 2) }] };
           }
-          return { content: [{ type: 'text', text: JSON.stringify(updated, null, 2) }] };
-        }
 
-        case 'delete_engagement': {
-          if (!id) {
+          case 'delete_engagement': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for delete_engagement' }],
+                isError: true,
+              };
+            }
+            const deleted = engagementRepo.delete(id);
+            if (!deleted) {
+              return {
+                content: [{ type: 'text', text: `Engagement not found: ${id}` }],
+                isError: true,
+              };
+            }
             return {
-              content: [
-                { type: 'text', text: 'id parameter is required for delete_engagement' },
-              ],
-              isError: true,
+              content: [{ type: 'text', text: `Engagement ${id} deleted successfully.` }],
             };
           }
-          const deleted = engagementRepo.delete(id);
-          if (!deleted) {
-            return {
-              content: [{ type: 'text', text: `Engagement not found: ${id}` }],
-              isError: true,
-            };
-          }
-          return {
-            content: [{ type: 'text', text: `Engagement ${id} deleted successfully.` }],
-          };
-        }
 
-        // ----------------------------------------------------------------
-        // Run actions
-        // ----------------------------------------------------------------
-        case 'create_run': {
-          if (!engagementId) {
-            return {
-              content: [
-                { type: 'text', text: 'engagementId parameter is required for create_run' },
-              ],
-              isError: true,
-            };
+          // ----------------------------------------------------------------
+          // Run actions
+          // ----------------------------------------------------------------
+          case 'create_run': {
+            if (!engagementId) {
+              return {
+                content: [
+                  { type: 'text', text: 'engagementId parameter is required for create_run' },
+                ],
+                isError: true,
+              };
+            }
+            if (!triggerKind) {
+              return {
+                content: [
+                  { type: 'text', text: 'triggerKind parameter is required for create_run' },
+                ],
+                isError: true,
+              };
+            }
+            if (!status) {
+              return {
+                content: [{ type: 'text', text: 'status parameter is required for create_run' }],
+                isError: true,
+              };
+            }
+            const run = runRepo.create({
+              engagementId,
+              triggerKind,
+              triggerRef,
+              status,
+            });
+            return { content: [{ type: 'text', text: JSON.stringify(run, null, 2) }] };
           }
-          if (!triggerKind) {
-            return {
-              content: [
-                { type: 'text', text: 'triggerKind parameter is required for create_run' },
-              ],
-              isError: true,
-            };
-          }
-          if (!status) {
-            return {
-              content: [
-                { type: 'text', text: 'status parameter is required for create_run' },
-              ],
-              isError: true,
-            };
-          }
-          const run = runRepo.create({
-            engagementId,
-            triggerKind,
-            triggerRef,
-            status,
-          });
-          return { content: [{ type: 'text', text: JSON.stringify(run, null, 2) }] };
-        }
 
-        case 'list_runs': {
-          if (!engagementId) {
-            return {
-              content: [
-                { type: 'text', text: 'engagementId parameter is required for list_runs' },
-              ],
-              isError: true,
-            };
+          case 'list_runs': {
+            if (!engagementId) {
+              return {
+                content: [
+                  { type: 'text', text: 'engagementId parameter is required for list_runs' },
+                ],
+                isError: true,
+              };
+            }
+            const runs = runRepo.findByEngagement(engagementId, limit);
+            return { content: [{ type: 'text', text: JSON.stringify(runs, null, 2) }] };
           }
-          const runs = runRepo.findByEngagement(engagementId, limit);
-          return { content: [{ type: 'text', text: JSON.stringify(runs, null, 2) }] };
-        }
 
-        case 'get_run': {
-          if (!id) {
-            return {
-              content: [{ type: 'text', text: 'id parameter is required for get_run' }],
-              isError: true,
-            };
+          case 'get_run': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for get_run' }],
+                isError: true,
+              };
+            }
+            const run = runRepo.findById(id);
+            if (!run) {
+              return {
+                content: [{ type: 'text', text: `Run not found: ${id}` }],
+                isError: true,
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(run, null, 2) }] };
           }
-          const run = runRepo.findById(id);
-          if (!run) {
-            return {
-              content: [{ type: 'text', text: `Run not found: ${id}` }],
-              isError: true,
-            };
-          }
-          return { content: [{ type: 'text', text: JSON.stringify(run, null, 2) }] };
-        }
 
-        case 'update_run_status': {
-          if (!id) {
-            return {
-              content: [
-                { type: 'text', text: 'id parameter is required for update_run_status' },
-              ],
-              isError: true,
-            };
+          case 'update_run_status': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for update_run_status' }],
+                isError: true,
+              };
+            }
+            if (!status) {
+              return {
+                content: [
+                  { type: 'text', text: 'status parameter is required for update_run_status' },
+                ],
+                isError: true,
+              };
+            }
+            const updatedRun = runRepo.updateStatus(id, status, summaryJson);
+            if (!updatedRun) {
+              return {
+                content: [{ type: 'text', text: `Run not found: ${id}` }],
+                isError: true,
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(updatedRun, null, 2) }] };
           }
-          if (!status) {
-            return {
-              content: [
-                { type: 'text', text: 'status parameter is required for update_run_status' },
-              ],
-              isError: true,
-            };
-          }
-          const updatedRun = runRepo.updateStatus(id, status, summaryJson);
-          if (!updatedRun) {
-            return {
-              content: [{ type: 'text', text: `Run not found: ${id}` }],
-              isError: true,
-            };
-          }
-          return { content: [{ type: 'text', text: JSON.stringify(updatedRun, null, 2) }] };
-        }
 
-        // ----------------------------------------------------------------
-        // ActionQueue actions
-        // ----------------------------------------------------------------
-        case 'enqueue_action': {
-          if (!engagementId) {
+          // ----------------------------------------------------------------
+          // ActionQueue actions
+          // ----------------------------------------------------------------
+          case 'enqueue_action': {
+            if (!engagementId) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'engagementId parameter is required for enqueue_action',
+                  },
+                ],
+                isError: true,
+              };
+            }
+            if (!kind) {
+              return {
+                content: [{ type: 'text', text: 'kind parameter is required for enqueue_action' }],
+                isError: true,
+              };
+            }
+            if (!dedupeKey) {
+              return {
+                content: [
+                  { type: 'text', text: 'dedupeKey parameter is required for enqueue_action' },
+                ],
+                isError: true,
+              };
+            }
+            const item = actionQueueRepo.enqueue({
+              engagementId,
+              runId,
+              parentActionId,
+              kind,
+              priority,
+              dedupeKey,
+              paramsJson,
+              state,
+              maxAttempts,
+              availableAt,
+            });
+            return { content: [{ type: 'text', text: JSON.stringify(item, null, 2) }] };
+          }
+
+          case 'poll_action': {
+            if (!leaseOwner) {
+              return {
+                content: [
+                  { type: 'text', text: 'leaseOwner parameter is required for poll_action' },
+                ],
+                isError: true,
+              };
+            }
+            const polled = actionQueueRepo.poll(leaseOwner, leaseDurationSec);
+            if (!polled) {
+              return {
+                content: [{ type: 'text', text: 'No action available to poll' }],
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(polled, null, 2) }] };
+          }
+
+          case 'complete_action': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for complete_action' }],
+                isError: true,
+              };
+            }
+            const completed = actionQueueRepo.complete(id);
+            if (!completed) {
+              return {
+                content: [
+                  { type: 'text', text: `Action not found or not in running state: ${id}` },
+                ],
+                isError: true,
+              };
+            }
+            return {
+              content: [{ type: 'text', text: `Action ${id} completed successfully.` }],
+            };
+          }
+
+          case 'fail_action': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for fail_action' }],
+                isError: true,
+              };
+            }
+            if (!errorMessage) {
+              return {
+                content: [
+                  { type: 'text', text: 'errorMessage parameter is required for fail_action' },
+                ],
+                isError: true,
+              };
+            }
+            const failed = actionQueueRepo.fail(id, errorMessage);
+            if (!failed) {
+              return {
+                content: [
+                  { type: 'text', text: `Action not found or not in running state: ${id}` },
+                ],
+                isError: true,
+              };
+            }
+            const afterFail = actionQueueRepo.findById(id);
+            return {
+              content: [{ type: 'text', text: JSON.stringify(afterFail, null, 2) }],
+            };
+          }
+
+          case 'cancel_action': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for cancel_action' }],
+                isError: true,
+              };
+            }
+            const cancelled = actionQueueRepo.cancel(id);
+            if (!cancelled) {
+              return {
+                content: [{ type: 'text', text: `Action not found: ${id}` }],
+                isError: true,
+              };
+            }
+            return {
+              content: [{ type: 'text', text: `Action ${id} cancelled successfully.` }],
+            };
+          }
+
+          case 'list_actions': {
+            if (!engagementId) {
+              return {
+                content: [
+                  { type: 'text', text: 'engagementId parameter is required for list_actions' },
+                ],
+                isError: true,
+              };
+            }
+            const actions = actionQueueRepo.findByEngagement(engagementId, state);
+            return { content: [{ type: 'text', text: JSON.stringify(actions, null, 2) }] };
+          }
+
+          // ----------------------------------------------------------------
+          // ActionExecution actions
+          // ----------------------------------------------------------------
+          case 'get_execution': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for get_execution' }],
+                isError: true,
+              };
+            }
+            const execution = actionExecRepo.findById(id);
+            if (!execution) {
+              return {
+                content: [{ type: 'text', text: `Execution not found: ${id}` }],
+                isError: true,
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(execution, null, 2) }] };
+          }
+
+          case 'list_executions': {
+            if (actionId) {
+              const executions = actionExecRepo.findByAction(actionId);
+              return {
+                content: [{ type: 'text', text: JSON.stringify(executions, null, 2) }],
+              };
+            }
+            if (runId) {
+              const executions = actionExecRepo.findByRun(runId);
+              return {
+                content: [{ type: 'text', text: JSON.stringify(executions, null, 2) }],
+              };
+            }
             return {
               content: [
                 {
                   type: 'text',
-                  text: 'engagementId parameter is required for enqueue_action',
+                  text: 'actionId or runId parameter is required for list_executions',
                 },
               ],
               isError: true,
             };
           }
-          if (!kind) {
-            return {
-              content: [
-                { type: 'text', text: 'kind parameter is required for enqueue_action' },
-              ],
-              isError: true,
-            };
-          }
-          if (!dedupeKey) {
-            return {
-              content: [
-                { type: 'text', text: 'dedupeKey parameter is required for enqueue_action' },
-              ],
-              isError: true,
-            };
-          }
-          const item = actionQueueRepo.enqueue({
-            engagementId,
-            runId,
-            parentActionId,
-            kind,
-            priority,
-            dedupeKey,
-            paramsJson,
-            state,
-            maxAttempts,
-            availableAt,
-          });
-          return { content: [{ type: 'text', text: JSON.stringify(item, null, 2) }] };
         }
-
-        case 'poll_action': {
-          if (!leaseOwner) {
-            return {
-              content: [
-                { type: 'text', text: 'leaseOwner parameter is required for poll_action' },
-              ],
-              isError: true,
-            };
-          }
-          const polled = actionQueueRepo.poll(leaseOwner, leaseDurationSec);
-          if (!polled) {
-            return {
-              content: [{ type: 'text', text: 'No action available to poll' }],
-            };
-          }
-          return { content: [{ type: 'text', text: JSON.stringify(polled, null, 2) }] };
-        }
-
-        case 'complete_action': {
-          if (!id) {
-            return {
-              content: [
-                { type: 'text', text: 'id parameter is required for complete_action' },
-              ],
-              isError: true,
-            };
-          }
-          const completed = actionQueueRepo.complete(id);
-          if (!completed) {
-            return {
-              content: [
-                { type: 'text', text: `Action not found or not in running state: ${id}` },
-              ],
-              isError: true,
-            };
-          }
-          return {
-            content: [{ type: 'text', text: `Action ${id} completed successfully.` }],
-          };
-        }
-
-        case 'fail_action': {
-          if (!id) {
-            return {
-              content: [
-                { type: 'text', text: 'id parameter is required for fail_action' },
-              ],
-              isError: true,
-            };
-          }
-          if (!errorMessage) {
-            return {
-              content: [
-                { type: 'text', text: 'errorMessage parameter is required for fail_action' },
-              ],
-              isError: true,
-            };
-          }
-          const failed = actionQueueRepo.fail(id, errorMessage);
-          if (!failed) {
-            return {
-              content: [
-                { type: 'text', text: `Action not found or not in running state: ${id}` },
-              ],
-              isError: true,
-            };
-          }
-          const afterFail = actionQueueRepo.findById(id);
-          return {
-            content: [{ type: 'text', text: JSON.stringify(afterFail, null, 2) }],
-          };
-        }
-
-        case 'cancel_action': {
-          if (!id) {
-            return {
-              content: [
-                { type: 'text', text: 'id parameter is required for cancel_action' },
-              ],
-              isError: true,
-            };
-          }
-          const cancelled = actionQueueRepo.cancel(id);
-          if (!cancelled) {
-            return {
-              content: [{ type: 'text', text: `Action not found: ${id}` }],
-              isError: true,
-            };
-          }
-          return {
-            content: [{ type: 'text', text: `Action ${id} cancelled successfully.` }],
-          };
-        }
-
-        case 'list_actions': {
-          if (!engagementId) {
-            return {
-              content: [
-                { type: 'text', text: 'engagementId parameter is required for list_actions' },
-              ],
-              isError: true,
-            };
-          }
-          const actions = actionQueueRepo.findByEngagement(engagementId, state);
-          return { content: [{ type: 'text', text: JSON.stringify(actions, null, 2) }] };
-        }
-
-        // ----------------------------------------------------------------
-        // ActionExecution actions
-        // ----------------------------------------------------------------
-        case 'get_execution': {
-          if (!id) {
-            return {
-              content: [
-                { type: 'text', text: 'id parameter is required for get_execution' },
-              ],
-              isError: true,
-            };
-          }
-          const execution = actionExecRepo.findById(id);
-          if (!execution) {
-            return {
-              content: [{ type: 'text', text: `Execution not found: ${id}` }],
-              isError: true,
-            };
-          }
-          return { content: [{ type: 'text', text: JSON.stringify(execution, null, 2) }] };
-        }
-
-        case 'list_executions': {
-          if (actionId) {
-            const executions = actionExecRepo.findByAction(actionId);
-            return {
-              content: [{ type: 'text', text: JSON.stringify(executions, null, 2) }],
-            };
-          }
-          if (runId) {
-            const executions = actionExecRepo.findByRun(runId);
-            return {
-              content: [{ type: 'text', text: JSON.stringify(executions, null, 2) }],
-            };
-          }
-          return {
-            content: [
-              {
-                type: 'text',
-                text: 'actionId or runId parameter is required for list_executions',
-              },
-            ],
-            isError: true,
-          };
-        }
-      }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return {

--- a/src/types/operational.ts
+++ b/src/types/operational.ts
@@ -1,0 +1,218 @@
+/**
+ * sonobat — Operational entity types
+ *
+ * v5 運用テーブル（engagements, runs, action_queue, action_executions,
+ * findings, finding_events, risk_snapshots）のエンティティ型定義。
+ */
+
+// ============================================================
+// Engagement
+// ============================================================
+
+export interface Engagement {
+  id: string;
+  name: string;
+  environment: string;
+  scopeJson: string;
+  policyJson: string;
+  scheduleCron?: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateEngagementInput = {
+  name: string;
+  environment?: string;
+  scopeJson?: string;
+  policyJson?: string;
+  scheduleCron?: string;
+  status?: string;
+};
+
+// ============================================================
+// Run
+// ============================================================
+
+export interface Run {
+  id: string;
+  engagementId: string;
+  triggerKind: string;
+  triggerRef?: string;
+  status: string;
+  startedAt?: string;
+  finishedAt?: string;
+  summaryJson: string;
+  createdAt: string;
+}
+
+export type CreateRunInput = {
+  engagementId: string;
+  triggerKind: string;
+  triggerRef?: string;
+  status: string;
+};
+
+// ============================================================
+// ActionQueueItem
+// ============================================================
+
+export interface ActionQueueItem {
+  id: string;
+  engagementId: string;
+  runId?: string;
+  parentActionId?: string;
+  kind: string;
+  priority: number;
+  dedupeKey: string;
+  paramsJson: string;
+  state: string;
+  attemptCount: number;
+  maxAttempts: number;
+  availableAt: string;
+  leaseOwner?: string;
+  leaseExpiresAt?: string;
+  lastError?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateActionInput = {
+  engagementId: string;
+  runId?: string;
+  parentActionId?: string;
+  kind: string;
+  priority?: number;
+  dedupeKey: string;
+  paramsJson?: string;
+  state?: string;
+  maxAttempts?: number;
+  availableAt?: string;
+};
+
+// ============================================================
+// ActionExecution
+// ============================================================
+
+export interface ActionExecution {
+  id: string;
+  actionId: string;
+  runId?: string;
+  executor: string;
+  command?: string;
+  inputJson: string;
+  outputJson: string;
+  stdoutArtifactId?: string;
+  stderrArtifactId?: string;
+  exitCode?: number;
+  errorType?: string;
+  errorMessage?: string;
+  startedAt: string;
+  finishedAt?: string;
+  durationMs?: number;
+}
+
+export type CreateExecutionInput = {
+  actionId: string;
+  runId?: string;
+  executor: string;
+  command?: string;
+  inputJson?: string;
+};
+
+// ============================================================
+// Finding
+// ============================================================
+
+export interface Finding {
+  id: string;
+  engagementId: string;
+  canonicalKey: string;
+  nodeId?: string;
+  title: string;
+  severity: string;
+  confidence: string;
+  state: string;
+  stateReason?: string;
+  owner?: string;
+  ticketRef?: string;
+  firstSeenRunId?: string;
+  lastSeenRunId?: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  slaDueAt?: string;
+  attrsJson: string;
+}
+
+export type UpsertFindingInput = {
+  engagementId: string;
+  canonicalKey: string;
+  nodeId?: string;
+  title: string;
+  severity: string;
+  confidence: string;
+  state?: string;
+  runId?: string;
+  attrsJson?: string;
+};
+
+// ============================================================
+// FindingEvent
+// ============================================================
+
+export interface FindingEvent {
+  id: string;
+  findingId: string;
+  runId?: string;
+  eventType: string;
+  beforeJson: string;
+  afterJson: string;
+  artifactId?: string;
+  createdAt: string;
+}
+
+export type CreateFindingEventInput = {
+  eventType: string;
+  runId?: string;
+  beforeJson?: string;
+  afterJson?: string;
+  artifactId?: string;
+};
+
+// ============================================================
+// RiskSnapshot
+// ============================================================
+
+export interface RiskSnapshot {
+  id: string;
+  engagementId: string;
+  runId?: string;
+  score: number;
+  openCritical: number;
+  openHigh: number;
+  openMedium: number;
+  openLow: number;
+  openInfo: number;
+  openTotal: number;
+  attackPathCount: number;
+  exposedCredCount: number;
+  modelVersion?: string;
+  attrsJson: string;
+  createdAt: string;
+}
+
+export type CreateRiskSnapshotInput = {
+  engagementId: string;
+  runId?: string;
+  score: number;
+  openCritical?: number;
+  openHigh?: number;
+  openMedium?: number;
+  openLow?: number;
+  openInfo?: number;
+  openTotal?: number;
+  attackPathCount?: number;
+  exposedCredCount?: number;
+  modelVersion?: string;
+  attrsJson?: string;
+};

--- a/tests/db/migrations/v5.test.ts
+++ b/tests/db/migrations/v5.test.ts
@@ -15,9 +15,11 @@ describe('Migration v5: file_mtime + 複合インデックス', () => {
   });
 
   it('technique_docs テーブルに file_mtime カラムが存在する', () => {
-    const columns = db
-      .prepare("PRAGMA table_info('technique_docs')")
-      .all() as Array<{ name: string; type: string; notnull: number }>;
+    const columns = db.prepare("PRAGMA table_info('technique_docs')").all() as Array<{
+      name: string;
+      type: string;
+      notnull: number;
+    }>;
 
     const fileMtimeCol = columns.find((c) => c.name === 'file_mtime');
     expect(fileMtimeCol).toBeDefined();
@@ -274,21 +276,33 @@ describe('Migration v5: 運用テーブル (engagements, runs, action_queue, etc
     db.prepare(
       `INSERT INTO action_queue (id, engagement_id, run_id, kind, priority, dedupe_key, params_json, state, available_at, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    ).run('aq-sn1', 'eng-sn1', 'run-sn1', 'nmap_scan', 100, 'scan:sn', '{}', 'succeeded', now, now, now);
+    ).run(
+      'aq-sn1',
+      'eng-sn1',
+      'run-sn1',
+      'nmap_scan',
+      100,
+      'scan:sn',
+      '{}',
+      'succeeded',
+      now,
+      now,
+      now,
+    );
 
     // run 削除前: run_id が設定されている
-    const before = db
-      .prepare('SELECT run_id FROM action_queue WHERE id = ?')
-      .get('aq-sn1') as { run_id: string | null };
+    const before = db.prepare('SELECT run_id FROM action_queue WHERE id = ?').get('aq-sn1') as {
+      run_id: string | null;
+    };
     expect(before.run_id).toBe('run-sn1');
 
     // run を削除
     db.prepare('DELETE FROM runs WHERE id = ?').run('run-sn1');
 
     // run 削除後: run_id が NULL になっている
-    const after = db
-      .prepare('SELECT run_id FROM action_queue WHERE id = ?')
-      .get('aq-sn1') as { run_id: string | null };
+    const after = db.prepare('SELECT run_id FROM action_queue WHERE id = ?').get('aq-sn1') as {
+      run_id: string | null;
+    };
     expect(after.run_id).toBeNull();
   });
 
@@ -394,7 +408,9 @@ describe('Migration v5: 運用テーブル (engagements, runs, action_queue, etc
     ).run('run-c2', 'eng-c1', 'schedule', 'running', '{}', now);
 
     // 削除前: runs が 2 件
-    const before = db.prepare("SELECT COUNT(*) AS cnt FROM runs WHERE engagement_id = 'eng-c1'").get() as {
+    const before = db
+      .prepare("SELECT COUNT(*) AS cnt FROM runs WHERE engagement_id = 'eng-c1'")
+      .get() as {
       cnt: number;
     };
     expect(before.cnt).toBe(2);
@@ -403,7 +419,9 @@ describe('Migration v5: 運用テーブル (engagements, runs, action_queue, etc
     db.prepare('DELETE FROM engagements WHERE id = ?').run('eng-c1');
 
     // 削除後: runs が 0 件
-    const after = db.prepare("SELECT COUNT(*) AS cnt FROM runs WHERE engagement_id = 'eng-c1'").get() as {
+    const after = db
+      .prepare("SELECT COUNT(*) AS cnt FROM runs WHERE engagement_id = 'eng-c1'")
+      .get() as {
       cnt: number;
     };
     expect(after.cnt).toBe(0);
@@ -435,9 +453,10 @@ describe('Migration v5: backfill（既存データのデフォルト engagement 
     setSchemaVersion(db, 4);
 
     // 既存 scans データを挿入
-    db.prepare(
-      `INSERT INTO scans (id, started_at) VALUES (?, ?)`,
-    ).run('scan-bf1', '2025-01-01T00:00:00Z');
+    db.prepare(`INSERT INTO scans (id, started_at) VALUES (?, ?)`).run(
+      'scan-bf1',
+      '2025-01-01T00:00:00Z',
+    );
 
     db.prepare(
       `INSERT INTO artifacts (id, scan_id, tool, kind, path, captured_at) VALUES (?, ?, ?, ?, ?, ?)`,
@@ -453,28 +472,28 @@ describe('Migration v5: backfill（既存データのデフォルト engagement 
     setSchemaVersion(db, 5);
 
     // デフォルト engagement が存在する
-    const eng = db
-      .prepare("SELECT * FROM engagements WHERE name = 'default'")
-      .get() as Record<string, unknown> | undefined;
+    const eng = db.prepare("SELECT * FROM engagements WHERE name = 'default'").get() as
+      | Record<string, unknown>
+      | undefined;
     expect(eng).toBeDefined();
     expect(eng!.status).toBe('active');
 
     // scans.engagement_id がデフォルト engagement に設定されている
-    const scan = db
-      .prepare('SELECT engagement_id FROM scans WHERE id = ?')
-      .get('scan-bf1') as { engagement_id: string | null };
+    const scan = db.prepare('SELECT engagement_id FROM scans WHERE id = ?').get('scan-bf1') as {
+      engagement_id: string | null;
+    };
     expect(scan.engagement_id).toBe(eng!.id);
 
     // scan_id がある artifact はデフォルト engagement に設定されている
-    const art1 = db
-      .prepare('SELECT engagement_id FROM artifacts WHERE id = ?')
-      .get('art-bf1') as { engagement_id: string | null };
+    const art1 = db.prepare('SELECT engagement_id FROM artifacts WHERE id = ?').get('art-bf1') as {
+      engagement_id: string | null;
+    };
     expect(art1.engagement_id).toBe(eng!.id);
 
     // scan_id が NULL の artifact もデフォルト engagement に設定されている
-    const art2 = db
-      .prepare('SELECT engagement_id FROM artifacts WHERE id = ?')
-      .get('art-bf2') as { engagement_id: string | null };
+    const art2 = db.prepare('SELECT engagement_id FROM artifacts WHERE id = ?').get('art-bf2') as {
+      engagement_id: string | null;
+    };
     expect(art2.engagement_id).toBe(eng!.id);
   });
 
@@ -482,9 +501,7 @@ describe('Migration v5: backfill（既存データのデフォルト engagement 
     db = new Database(':memory:');
     migrateDatabase(db);
 
-    const count = db
-      .prepare('SELECT COUNT(*) AS cnt FROM engagements')
-      .get() as { cnt: number };
+    const count = db.prepare('SELECT COUNT(*) AS cnt FROM engagements').get() as { cnt: number };
     expect(count.cnt).toBe(0);
   });
 
@@ -515,9 +532,7 @@ describe('Migration v5: backfill（既存データのデフォルト engagement 
     setSchemaVersion(db, 5);
 
     // engagement は作成されない
-    const engCount = db
-      .prepare('SELECT COUNT(*) AS cnt FROM engagements')
-      .get() as { cnt: number };
+    const engCount = db.prepare('SELECT COUNT(*) AS cnt FROM engagements').get() as { cnt: number };
     expect(engCount.cnt).toBe(0);
 
     // artifact の engagement_id は NULL のまま

--- a/tests/db/repository/action-execution-repository.test.ts
+++ b/tests/db/repository/action-execution-repository.test.ts
@@ -39,10 +39,7 @@ function insertTestAction(
 }
 
 /** テスト用 run レコードを挿入し id を返す */
-function insertTestRun(
-  db: InstanceType<typeof Database>,
-  engagementId: string,
-): string {
+function insertTestRun(db: InstanceType<typeof Database>, engagementId: string): string {
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
   db.prepare(
@@ -83,9 +80,7 @@ describe('ActionExecutionRepository', () => {
       });
 
       expect(exec.id).toBeDefined();
-      expect(exec.id).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-      );
+      expect(exec.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(exec.actionId).toBe(actionId);
       expect(exec.executor).toBe('nmap-executor');
       expect(exec.command).toBe('nmap -sV 10.0.0.1');

--- a/tests/db/repository/action-execution-repository.test.ts
+++ b/tests/db/repository/action-execution-repository.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { ActionExecutionRepository } from '../../../src/db/repository/action-execution-repository.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+import type { ActionExecution } from '../../../src/types/operational.js';
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+/** テスト用 :memory: DB を作成しマイグレーション済みで返す */
+function createTestDb(): InstanceType<typeof Database> {
+  const db = new Database(':memory:');
+  migrateDatabase(db);
+  return db;
+}
+
+/** テスト用 engagement を作成し id を返す */
+function insertTestEngagement(db: InstanceType<typeof Database>): string {
+  const repo = new EngagementRepository(db);
+  return repo.create({ name: 'Test Engagement' }).id;
+}
+
+/** テスト用 action_queue レコードを挿入し id を返す */
+function insertTestAction(
+  db: InstanceType<typeof Database>,
+  engagementId: string,
+  runId?: string,
+): string {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO action_queue (id, engagement_id, run_id, kind, priority, dedupe_key, params_json, state, attempt_count, max_attempts, available_at, created_at, updated_at)
+     VALUES (?, ?, ?, 'nmap_scan', 100, ?, '{}', 'queued', 0, 3, ?, ?, ?)`,
+  ).run(id, engagementId, runId ?? null, `dedupe-${id}`, now, now, now);
+  return id;
+}
+
+/** テスト用 run レコードを挿入し id を返す */
+function insertTestRun(
+  db: InstanceType<typeof Database>,
+  engagementId: string,
+): string {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO runs (id, engagement_id, trigger_kind, status, summary_json, created_at)
+     VALUES (?, ?, 'manual', 'running', '{}', ?)`,
+  ).run(id, engagementId, now);
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+describe('ActionExecutionRepository', () => {
+  let db: InstanceType<typeof Database>;
+  let repo: ActionExecutionRepository;
+  let engagementId: string;
+  let actionId: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new ActionExecutionRepository(db);
+    engagementId = insertTestEngagement(db);
+    actionId = insertTestAction(db, engagementId);
+  });
+
+  // =======================================================================
+  // create()
+  // =======================================================================
+
+  describe('create()', () => {
+    it('基本作成 — creates execution with all fields verified, started_at=now, inputJson defaults to {}', () => {
+      const exec = repo.create({
+        actionId,
+        executor: 'nmap-executor',
+        command: 'nmap -sV 10.0.0.1',
+        inputJson: '{"target":"10.0.0.1"}',
+      });
+
+      expect(exec.id).toBeDefined();
+      expect(exec.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(exec.actionId).toBe(actionId);
+      expect(exec.executor).toBe('nmap-executor');
+      expect(exec.command).toBe('nmap -sV 10.0.0.1');
+      expect(exec.inputJson).toBe('{"target":"10.0.0.1"}');
+      expect(exec.outputJson).toBe('{}');
+      expect(exec.startedAt).toBeDefined();
+      // startedAt should be a valid ISO string
+      expect(() => new Date(exec.startedAt)).not.toThrow();
+      expect(exec.finishedAt).toBeUndefined();
+      expect(exec.durationMs).toBeUndefined();
+      expect(exec.exitCode).toBeUndefined();
+      expect(exec.errorType).toBeUndefined();
+      expect(exec.errorMessage).toBeUndefined();
+      expect(exec.stdoutArtifactId).toBeUndefined();
+      expect(exec.stderrArtifactId).toBeUndefined();
+    });
+
+    it('デフォルト値 — inputJson={}, outputJson={}, no exit_code/error/finished_at/duration', () => {
+      const exec = repo.create({
+        actionId,
+        executor: 'nuclei-executor',
+      });
+
+      expect(exec.inputJson).toBe('{}');
+      expect(exec.outputJson).toBe('{}');
+      expect(exec.command).toBeUndefined();
+      expect(exec.runId).toBeUndefined();
+      expect(exec.exitCode).toBeUndefined();
+      expect(exec.errorType).toBeUndefined();
+      expect(exec.errorMessage).toBeUndefined();
+      expect(exec.finishedAt).toBeUndefined();
+      expect(exec.durationMs).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // findById()
+  // =======================================================================
+
+  describe('findById()', () => {
+    it('存在するID — returns the execution', () => {
+      const created = repo.create({
+        actionId,
+        executor: 'nmap-executor',
+        command: 'nmap -sV 10.0.0.1',
+      });
+
+      const found = repo.findById(created.id);
+
+      expect(found).toBeDefined();
+      expect(found!.id).toBe(created.id);
+      expect(found!.actionId).toBe(actionId);
+      expect(found!.executor).toBe('nmap-executor');
+      expect(found!.command).toBe('nmap -sV 10.0.0.1');
+      expect(found!.startedAt).toBe(created.startedAt);
+    });
+
+    it('存在しないID — returns undefined', () => {
+      const found = repo.findById(crypto.randomUUID());
+      expect(found).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // findByAction()
+  // =======================================================================
+
+  describe('findByAction()', () => {
+    it('アクションフィルタ — returns executions for given action_id, ordered by started_at DESC', () => {
+      const actionId2 = insertTestAction(db, engagementId);
+
+      // action 1 に 2 件作成（started_at に明確な時間差を設ける）
+      const execId1 = crypto.randomUUID();
+      const execId2 = crypto.randomUUID();
+
+      db.prepare(
+        `INSERT INTO action_executions (id, action_id, executor, input_json, output_json, started_at)
+         VALUES (?, ?, 'exec-1', '{}', '{}', ?)`,
+      ).run(execId1, actionId, '2026-01-01T00:00:00.000Z');
+
+      db.prepare(
+        `INSERT INTO action_executions (id, action_id, executor, input_json, output_json, started_at)
+         VALUES (?, ?, 'exec-2', '{}', '{}', ?)`,
+      ).run(execId2, actionId, '2026-01-02T00:00:00.000Z');
+
+      // action 2 に 1 件作成
+      repo.create({ actionId: actionId2, executor: 'other-executor' });
+
+      const executions = repo.findByAction(actionId);
+
+      expect(executions).toHaveLength(2);
+      expect(executions.every((e: ActionExecution) => e.actionId === actionId)).toBe(true);
+
+      // started_at DESC 順：execId2 が先（より新しい）
+      expect(executions[0].id).toBe(execId2);
+      expect(executions[1].id).toBe(execId1);
+    });
+  });
+
+  // =======================================================================
+  // findByRun()
+  // =======================================================================
+
+  describe('findByRun()', () => {
+    it('ランフィルタ — returns executions for given run_id, ordered by started_at DESC', () => {
+      const runId1 = insertTestRun(db, engagementId);
+      const runId2 = insertTestRun(db, engagementId);
+
+      // run 1 に 2 件作成（started_at に明確な時間差を設ける）
+      const execId1 = crypto.randomUUID();
+      const execId2 = crypto.randomUUID();
+
+      db.prepare(
+        `INSERT INTO action_executions (id, action_id, run_id, executor, input_json, output_json, started_at)
+         VALUES (?, ?, ?, 'exec-1', '{}', '{}', ?)`,
+      ).run(execId1, actionId, runId1, '2026-01-01T00:00:00.000Z');
+
+      db.prepare(
+        `INSERT INTO action_executions (id, action_id, run_id, executor, input_json, output_json, started_at)
+         VALUES (?, ?, ?, 'exec-2', '{}', '{}', ?)`,
+      ).run(execId2, actionId, runId1, '2026-01-02T00:00:00.000Z');
+
+      // run 2 に 1 件作成
+      repo.create({ actionId, runId: runId2, executor: 'other-executor' });
+
+      const executions = repo.findByRun(runId1);
+
+      expect(executions).toHaveLength(2);
+      expect(executions.every((e: ActionExecution) => e.runId === runId1)).toBe(true);
+
+      // started_at DESC 順：execId2 が先（より新しい）
+      expect(executions[0].id).toBe(execId2);
+      expect(executions[1].id).toBe(execId1);
+    });
+  });
+
+  // =======================================================================
+  // complete()
+  // =======================================================================
+
+  describe('complete()', () => {
+    it('正常完了 — sets finished_at, duration_ms, outputJson, exitCode', () => {
+      const exec = repo.create({
+        actionId,
+        executor: 'nmap-executor',
+        command: 'nmap -sV 10.0.0.1',
+      });
+
+      const completed = repo.complete(exec.id, {
+        outputJson: '{"hosts":[{"ip":"10.0.0.1","ports":[22,80]}]}',
+        exitCode: 0,
+      });
+
+      expect(completed).toBeDefined();
+      expect(completed!.id).toBe(exec.id);
+      expect(completed!.outputJson).toBe('{"hosts":[{"ip":"10.0.0.1","ports":[22,80]}]}');
+      expect(completed!.exitCode).toBe(0);
+      expect(completed!.finishedAt).toBeDefined();
+      expect(completed!.durationMs).toBeDefined();
+      expect(typeof completed!.durationMs).toBe('number');
+      expect(completed!.errorType).toBeUndefined();
+      expect(completed!.errorMessage).toBeUndefined();
+    });
+
+    it('エラー完了 — sets errorType and errorMessage along with exitCode', () => {
+      const exec = repo.create({
+        actionId,
+        executor: 'nmap-executor',
+        command: 'nmap -sV 10.0.0.1',
+      });
+
+      const completed = repo.complete(exec.id, {
+        exitCode: 1,
+        errorType: 'TIMEOUT',
+        errorMessage: 'Scan timed out after 300s',
+      });
+
+      expect(completed).toBeDefined();
+      expect(completed!.exitCode).toBe(1);
+      expect(completed!.errorType).toBe('TIMEOUT');
+      expect(completed!.errorMessage).toBe('Scan timed out after 300s');
+      expect(completed!.finishedAt).toBeDefined();
+      expect(completed!.durationMs).toBeDefined();
+    });
+
+    it('duration_ms 自動計算 — duration_ms should be >= 0', () => {
+      // started_at を明示的に過去の時刻で挿入して duration を検証
+      const execId = crypto.randomUUID();
+      const startedAt = '2025-01-01T00:00:00.000Z';
+
+      db.prepare(
+        `INSERT INTO action_executions (id, action_id, executor, input_json, output_json, started_at)
+         VALUES (?, ?, 'test-executor', '{}', '{}', ?)`,
+      ).run(execId, actionId, startedAt);
+
+      const completed = repo.complete(execId, {
+        outputJson: '{"result":"ok"}',
+        exitCode: 0,
+      });
+
+      expect(completed).toBeDefined();
+      expect(completed!.durationMs).toBeDefined();
+      expect(completed!.durationMs!).toBeGreaterThanOrEqual(0);
+      // duration_ms should match finishedAt - startedAt
+      const expectedDuration =
+        new Date(completed!.finishedAt!).getTime() - new Date(startedAt).getTime();
+      expect(completed!.durationMs).toBe(expectedDuration);
+    });
+
+    it('存在しないID — returns undefined', () => {
+      const result = repo.complete(crypto.randomUUID(), {
+        outputJson: '{}',
+        exitCode: 0,
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/tests/db/repository/action-queue-repository.test.ts
+++ b/tests/db/repository/action-queue-repository.test.ts
@@ -48,9 +48,7 @@ describe('ActionQueueRepository', () => {
       });
 
       expect(item.id).toBeDefined();
-      expect(item.id).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-      );
+      expect(item.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(item.engagementId).toBe(engagementId);
       expect(item.runId).toBeUndefined();
       expect(item.parentActionId).toBeUndefined();

--- a/tests/db/repository/action-queue-repository.test.ts
+++ b/tests/db/repository/action-queue-repository.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { ActionQueueRepository } from '../../../src/db/repository/action-queue-repository.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+import type { ActionQueueItem } from '../../../src/types/operational.js';
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+/** テスト用 :memory: DB を作成しマイグレーション済みで返す */
+function createTestDb(): InstanceType<typeof Database> {
+  const db = new Database(':memory:');
+  migrateDatabase(db);
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+describe('ActionQueueRepository', () => {
+  let db: InstanceType<typeof Database>;
+  let repo: ActionQueueRepository;
+  let engagementRepo: EngagementRepository;
+  let engagementId: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new ActionQueueRepository(db);
+    engagementRepo = new EngagementRepository(db);
+    const engagement = engagementRepo.create({ name: 'Test Engagement' });
+    engagementId = engagement.id;
+  });
+
+  // =======================================================================
+  // enqueue()
+  // =======================================================================
+
+  describe('enqueue()', () => {
+    it('基本作成 — creates an action with all fields and correct defaults', () => {
+      const item = repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:10.0.0.0/24',
+      });
+
+      expect(item.id).toBeDefined();
+      expect(item.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(item.engagementId).toBe(engagementId);
+      expect(item.runId).toBeUndefined();
+      expect(item.parentActionId).toBeUndefined();
+      expect(item.kind).toBe('nmap_scan');
+      expect(item.priority).toBe(100);
+      expect(item.dedupeKey).toBe('nmap:10.0.0.0/24');
+      expect(item.paramsJson).toBe('{}');
+      expect(item.state).toBe('queued');
+      expect(item.attemptCount).toBe(0);
+      expect(item.maxAttempts).toBe(3);
+      expect(item.availableAt).toBeDefined();
+      expect(item.leaseOwner).toBeUndefined();
+      expect(item.leaseExpiresAt).toBeUndefined();
+      expect(item.lastError).toBeUndefined();
+      expect(item.createdAt).toBeDefined();
+      expect(item.updatedAt).toBeDefined();
+      expect(item.createdAt).toBe(item.updatedAt);
+    });
+
+    it('dedupe_key重複（queued状態）で UNIQUE制約エラー', () => {
+      repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:10.0.0.0/24',
+      });
+
+      expect(() =>
+        repo.enqueue({
+          engagementId,
+          kind: 'nmap_scan',
+          dedupeKey: 'nmap:10.0.0.0/24',
+        }),
+      ).toThrow();
+    });
+
+    it('succeeded後の同じdedupe_keyは成功', () => {
+      const first = repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:10.0.0.0/24',
+      });
+
+      // poll して running にする
+      repo.poll('worker-1');
+      // complete して succeeded にする
+      repo.complete(first.id);
+
+      // 同じ dedupe_key で新しいアクションを作成できる
+      const second = repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:10.0.0.0/24',
+      });
+
+      expect(second.id).toBeDefined();
+      expect(second.id).not.toBe(first.id);
+      expect(second.dedupeKey).toBe('nmap:10.0.0.0/24');
+    });
+  });
+
+  // =======================================================================
+  // findById()
+  // =======================================================================
+
+  describe('findById()', () => {
+    it('存在するID — returns the item', () => {
+      const created = repo.enqueue({
+        engagementId,
+        kind: 'nuclei_scan',
+        dedupeKey: 'nuclei:example.com',
+        priority: 50,
+        paramsJson: '{"target":"example.com"}',
+        maxAttempts: 5,
+      });
+
+      const found = repo.findById(created.id);
+
+      expect(found).toBeDefined();
+      expect(found!.id).toBe(created.id);
+      expect(found!.engagementId).toBe(engagementId);
+      expect(found!.kind).toBe('nuclei_scan');
+      expect(found!.priority).toBe(50);
+      expect(found!.dedupeKey).toBe('nuclei:example.com');
+      expect(found!.paramsJson).toBe('{"target":"example.com"}');
+      expect(found!.state).toBe('queued');
+      expect(found!.maxAttempts).toBe(5);
+    });
+
+    it('存在しないID — returns undefined', () => {
+      const found = repo.findById(crypto.randomUUID());
+      expect(found).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // poll()
+  // =======================================================================
+
+  describe('poll()', () => {
+    it('基本ポーリング — returns oldest queued item, sets state=running with lease', () => {
+      const created = repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:10.0.0.1',
+      });
+
+      const polled = repo.poll('worker-1');
+
+      expect(polled).toBeDefined();
+      expect(polled!.id).toBe(created.id);
+      expect(polled!.state).toBe('running');
+      expect(polled!.leaseOwner).toBe('worker-1');
+      expect(polled!.leaseExpiresAt).toBeDefined();
+      expect(polled!.attemptCount).toBe(1);
+
+      // DB にも反映されていることを確認
+      const found = repo.findById(created.id);
+      expect(found!.state).toBe('running');
+      expect(found!.leaseOwner).toBe('worker-1');
+    });
+
+    it('キューが空 — returns undefined', () => {
+      const polled = repo.poll('worker-1');
+      expect(polled).toBeUndefined();
+    });
+
+    it('available_atが未来のアイテムはスキップ', () => {
+      const futureDate = new Date(Date.now() + 3600 * 1000).toISOString();
+
+      repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:future',
+        availableAt: futureDate,
+      });
+
+      const polled = repo.poll('worker-1');
+      expect(polled).toBeUndefined();
+    });
+
+    it('priority順 — lower priority number is polled first', () => {
+      // priority の低い方が先にポーリングされる（priority=10 < priority=100）
+      const lowPriority = repo.enqueue({
+        engagementId,
+        kind: 'critical_scan',
+        dedupeKey: 'scan:critical',
+        priority: 10,
+      });
+
+      repo.enqueue({
+        engagementId,
+        kind: 'normal_scan',
+        dedupeKey: 'scan:normal',
+        priority: 100,
+      });
+
+      const polled = repo.poll('worker-1');
+
+      expect(polled).toBeDefined();
+      expect(polled!.id).toBe(lowPriority.id);
+      expect(polled!.kind).toBe('critical_scan');
+    });
+  });
+
+  // =======================================================================
+  // complete()
+  // =======================================================================
+
+  describe('complete()', () => {
+    it('正常完了 — state→succeeded', () => {
+      const item = repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:complete-test',
+      });
+
+      // poll して running にする
+      repo.poll('worker-1');
+
+      const result = repo.complete(item.id);
+      expect(result).toBe(true);
+
+      const found = repo.findById(item.id);
+      expect(found!.state).toBe('succeeded');
+      expect(found!.attemptCount).toBe(1);
+    });
+
+    it('存在しないID — returns false', () => {
+      const result = repo.complete(crypto.randomUUID());
+      expect(result).toBe(false);
+    });
+  });
+
+  // =======================================================================
+  // fail()
+  // =======================================================================
+
+  describe('fail()', () => {
+    it('リトライ可能（attempt_count < maxAttempts） — state→queued with backoff', () => {
+      const item = repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:retry-test',
+        maxAttempts: 3,
+      });
+
+      // poll して running にする（attempt_count = 1）
+      repo.poll('worker-1');
+
+      const beforeFail = new Date();
+      const result = repo.fail(item.id, 'connection timeout');
+      expect(result).toBe(true);
+
+      const found = repo.findById(item.id);
+      expect(found!.state).toBe('queued');
+      expect(found!.attemptCount).toBe(1);
+      expect(found!.lastError).toBe('connection timeout');
+      expect(found!.leaseOwner).toBeUndefined();
+      expect(found!.leaseExpiresAt).toBeUndefined();
+
+      // available_at がバックオフ付きで更新されていることを確認
+      const availableAt = new Date(found!.availableAt);
+      expect(availableAt.getTime()).toBeGreaterThanOrEqual(beforeFail.getTime());
+    });
+
+    it('dead letter（attempt_count >= maxAttempts） — state→failed', () => {
+      const item = repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:dead-letter',
+        maxAttempts: 1,
+      });
+
+      // poll して running にする（attempt_count = 1）
+      repo.poll('worker-1');
+
+      // attempt_count(1) >= maxAttempts(1) なので dead letter
+      const result = repo.fail(item.id, 'permanent failure');
+      expect(result).toBe(true);
+
+      const found = repo.findById(item.id);
+      expect(found!.state).toBe('failed');
+      expect(found!.lastError).toBe('permanent failure');
+    });
+  });
+
+  // =======================================================================
+  // findByEngagement()
+  // =======================================================================
+
+  describe('findByEngagement()', () => {
+    it('エンゲージメントフィルタ — returns items for engagement', () => {
+      const engagement2 = engagementRepo.create({ name: 'Other Engagement' });
+
+      repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:eng1-a',
+      });
+      repo.enqueue({
+        engagementId,
+        kind: 'nuclei_scan',
+        dedupeKey: 'nuclei:eng1-b',
+      });
+      repo.enqueue({
+        engagementId: engagement2.id,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:eng2-a',
+      });
+
+      const items = repo.findByEngagement(engagementId);
+
+      expect(items).toHaveLength(2);
+      expect(items.every((i: ActionQueueItem) => i.engagementId === engagementId)).toBe(true);
+    });
+
+    it('stateフィルタ — returns items filtered by state', () => {
+      const item1 = repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:state-filter-a',
+      });
+      repo.enqueue({
+        engagementId,
+        kind: 'nuclei_scan',
+        dedupeKey: 'nuclei:state-filter-b',
+      });
+
+      // item1 を running にする
+      repo.poll('worker-1');
+
+      const queuedItems = repo.findByEngagement(engagementId, 'queued');
+      const runningItems = repo.findByEngagement(engagementId, 'running');
+
+      expect(queuedItems).toHaveLength(1);
+      expect(queuedItems[0].kind).toBe('nuclei_scan');
+
+      expect(runningItems).toHaveLength(1);
+      expect(runningItems[0].id).toBe(item1.id);
+      expect(runningItems[0].state).toBe('running');
+    });
+  });
+
+  // =======================================================================
+  // cancel()
+  // =======================================================================
+
+  describe('cancel()', () => {
+    it('正常キャンセル — state→cancelled', () => {
+      const item = repo.enqueue({
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:cancel-test',
+      });
+
+      const result = repo.cancel(item.id);
+      expect(result).toBe(true);
+
+      const found = repo.findById(item.id);
+      expect(found!.state).toBe('cancelled');
+    });
+
+    it('存在しないID — returns false', () => {
+      const result = repo.cancel(crypto.randomUUID());
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/tests/db/repository/engagement-repository.test.ts
+++ b/tests/db/repository/engagement-repository.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+import type { Engagement } from '../../../src/types/operational.js';
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+/** テスト用 :memory: DB を作成しマイグレーション済みで返す */
+function createTestDb(): InstanceType<typeof Database> {
+  const db = new Database(':memory:');
+  migrateDatabase(db);
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+describe('EngagementRepository', () => {
+  let db: InstanceType<typeof Database>;
+  let repo: EngagementRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new EngagementRepository(db);
+  });
+
+  // =======================================================================
+  // create()
+  // =======================================================================
+
+  describe('create()', () => {
+    it('基本作成 — creates an engagement and verifies all fields', () => {
+      const engagement = repo.create({
+        name: 'Test Engagement',
+        environment: 'prod',
+        scopeJson: '{"targets":["10.0.0.0/24"]}',
+        policyJson: '{"maxConcurrency":5}',
+        scheduleCron: '0 2 * * *',
+        status: 'active',
+      });
+
+      expect(engagement.id).toBeDefined();
+      expect(engagement.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(engagement.name).toBe('Test Engagement');
+      expect(engagement.environment).toBe('prod');
+      expect(engagement.scopeJson).toBe('{"targets":["10.0.0.0/24"]}');
+      expect(engagement.policyJson).toBe('{"maxConcurrency":5}');
+      expect(engagement.scheduleCron).toBe('0 2 * * *');
+      expect(engagement.status).toBe('active');
+      expect(engagement.createdAt).toBeDefined();
+      expect(engagement.updatedAt).toBeDefined();
+      expect(engagement.createdAt).toBe(engagement.updatedAt);
+    });
+
+    it('デフォルト値 — environment defaults to stg, scopeJson to {}, policyJson to {}', () => {
+      const engagement = repo.create({ name: 'Minimal Engagement' });
+
+      expect(engagement.environment).toBe('stg');
+      expect(engagement.scopeJson).toBe('{}');
+      expect(engagement.policyJson).toBe('{}');
+      expect(engagement.scheduleCron).toBeUndefined();
+      expect(engagement.status).toBe('active');
+    });
+  });
+
+  // =======================================================================
+  // findById()
+  // =======================================================================
+
+  describe('findById()', () => {
+    it('存在するID — returns the engagement', () => {
+      const created = repo.create({
+        name: 'Find Me',
+        environment: 'dev',
+      });
+
+      const found = repo.findById(created.id);
+
+      expect(found).toBeDefined();
+      expect(found!.id).toBe(created.id);
+      expect(found!.name).toBe('Find Me');
+      expect(found!.environment).toBe('dev');
+    });
+
+    it('存在しないID — returns undefined', () => {
+      const found = repo.findById(crypto.randomUUID());
+      expect(found).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // findByStatus()
+  // =======================================================================
+
+  describe('findByStatus()', () => {
+    it('ステータスフィルタ — finds only matching status', () => {
+      repo.create({ name: 'Active 1', status: 'active' });
+      repo.create({ name: 'Active 2', status: 'active' });
+      repo.create({ name: 'Archived', status: 'archived' });
+
+      const activeList = repo.findByStatus('active');
+      const archivedList = repo.findByStatus('archived');
+
+      expect(activeList).toHaveLength(2);
+      expect(activeList.every((e: Engagement) => e.status === 'active')).toBe(true);
+      expect(archivedList).toHaveLength(1);
+      expect(archivedList[0].name).toBe('Archived');
+    });
+  });
+
+  // =======================================================================
+  // list()
+  // =======================================================================
+
+  describe('list()', () => {
+    it('全件取得 — returns all engagements', () => {
+      repo.create({ name: 'Engagement A' });
+      repo.create({ name: 'Engagement B' });
+      repo.create({ name: 'Engagement C' });
+
+      const all = repo.list();
+      expect(all).toHaveLength(3);
+
+      const names = all.map((e: Engagement) => e.name).sort();
+      expect(names).toEqual(['Engagement A', 'Engagement B', 'Engagement C']);
+    });
+  });
+
+  // =======================================================================
+  // update()
+  // =======================================================================
+
+  describe('update()', () => {
+    it('フィールド更新 — updates specified fields, keeps others, updates updatedAt', () => {
+      const created = repo.create({
+        name: 'Original Name',
+        environment: 'stg',
+        scopeJson: '{"old":true}',
+      });
+
+      // 少し間を空けて updatedAt の差を出す
+      const updated = repo.update(created.id, {
+        name: 'Updated Name',
+        scopeJson: '{"new":true}',
+      });
+
+      expect(updated).toBeDefined();
+      expect(updated!.id).toBe(created.id);
+      expect(updated!.name).toBe('Updated Name');
+      expect(updated!.scopeJson).toBe('{"new":true}');
+      // 変更していないフィールドは保持される
+      expect(updated!.environment).toBe('stg');
+      expect(updated!.policyJson).toBe('{}');
+      expect(updated!.status).toBe('active');
+      // updatedAt は更新される
+      expect(updated!.updatedAt).toBeDefined();
+    });
+
+    it('存在しないID — returns undefined', () => {
+      const result = repo.update(crypto.randomUUID(), { name: 'Ghost' });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // delete()
+  // =======================================================================
+
+  describe('delete()', () => {
+    it('正常削除 — returns true, engagement is gone', () => {
+      const created = repo.create({ name: 'To Be Deleted' });
+      const result = repo.delete(created.id);
+
+      expect(result).toBe(true);
+
+      const found = repo.findById(created.id);
+      expect(found).toBeUndefined();
+    });
+
+    it('存在しないID — returns false', () => {
+      const result = repo.delete(crypto.randomUUID());
+      expect(result).toBe(false);
+    });
+
+    it('CASCADE で runs も削除される — deleting engagement cascades to runs table', () => {
+      const engagement = repo.create({ name: 'Cascade Test' });
+
+      // runs テーブルに直接行を挿入
+      const runId = crypto.randomUUID();
+      const now = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO runs (id, engagement_id, trigger_kind, status, summary_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(runId, engagement.id, 'manual', 'running', '{}', now);
+
+      // run が存在することを確認
+      const runBefore = db.prepare('SELECT id FROM runs WHERE id = ?').get(runId) as
+        | { id: string }
+        | undefined;
+      expect(runBefore).toBeDefined();
+
+      // engagement を削除 → CASCADE で run も消えるはず
+      const deleted = repo.delete(engagement.id);
+      expect(deleted).toBe(true);
+
+      const runAfter = db.prepare('SELECT id FROM runs WHERE id = ?').get(runId) as
+        | { id: string }
+        | undefined;
+      expect(runAfter).toBeUndefined();
+    });
+  });
+});

--- a/tests/db/repository/finding-repository.test.ts
+++ b/tests/db/repository/finding-repository.test.ts
@@ -78,9 +78,7 @@ describe('FindingRepository', () => {
 
       // Finding の各フィールドを検証
       const finding = result.finding;
-      expect(finding.id).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-      );
+      expect(finding.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(finding.engagementId).toBe(engagementId);
       expect(finding.canonicalKey).toBe('CVE-2024-1234:host:192.168.1.1');
       expect(finding.title).toBe('SQL Injection in login form');
@@ -355,9 +353,7 @@ describe('FindingRepository', () => {
         afterJson: '{"state":"reviewed"}',
       });
 
-      expect(event.id).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-      );
+      expect(event.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(event.findingId).toBe(finding.id);
       expect(event.eventType).toBe('manual_review');
       expect(event.runId).toBe(runId1);

--- a/tests/db/repository/finding-repository.test.ts
+++ b/tests/db/repository/finding-repository.test.ts
@@ -1,0 +1,448 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { FindingRepository } from '../../../src/db/repository/finding-repository.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+import { RunRepository } from '../../../src/db/repository/run-repository.js';
+import type { Finding, FindingEvent } from '../../../src/types/operational.js';
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+/** テスト用 :memory: DB を作成しマイグレーション済みで返す */
+function createTestDb(): InstanceType<typeof Database> {
+  const db = new Database(':memory:');
+  migrateDatabase(db);
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+describe('FindingRepository', () => {
+  let db: InstanceType<typeof Database>;
+  let repo: FindingRepository;
+  let engagementRepo: EngagementRepository;
+  let runRepo: RunRepository;
+  let engagementId: string;
+  let runId1: string;
+  let runId2: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new FindingRepository(db);
+    engagementRepo = new EngagementRepository(db);
+    runRepo = new RunRepository(db);
+
+    // テスト用エンゲージメントを事前作成
+    const engagement = engagementRepo.create({ name: 'Test Engagement' });
+    engagementId = engagement.id;
+
+    // テスト用 run を事前作成（外部キー制約を満たすため）
+    const run1 = runRepo.create({
+      engagementId,
+      triggerKind: 'manual',
+      status: 'running',
+    });
+    runId1 = run1.id;
+
+    const run2 = runRepo.create({
+      engagementId,
+      triggerKind: 'manual',
+      status: 'running',
+    });
+    runId2 = run2.id;
+  });
+
+  // =======================================================================
+  // upsert()
+  // =======================================================================
+
+  describe('upsert()', () => {
+    it('新規作成 — creates finding + finding_events has discovered event', () => {
+      const result = repo.upsert({
+        engagementId,
+        canonicalKey: 'CVE-2024-1234:host:192.168.1.1',
+        title: 'SQL Injection in login form',
+        severity: 'critical',
+        confidence: 'high',
+        runId: runId1,
+        attrsJson: '{"cve":"CVE-2024-1234"}',
+      });
+
+      // created フラグが true
+      expect(result.created).toBe(true);
+
+      // Finding の各フィールドを検証
+      const finding = result.finding;
+      expect(finding.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(finding.engagementId).toBe(engagementId);
+      expect(finding.canonicalKey).toBe('CVE-2024-1234:host:192.168.1.1');
+      expect(finding.title).toBe('SQL Injection in login form');
+      expect(finding.severity).toBe('critical');
+      expect(finding.confidence).toBe('high');
+      expect(finding.state).toBe('open');
+      expect(finding.firstSeenRunId).toBe(runId1);
+      expect(finding.lastSeenRunId).toBe(runId1);
+      expect(finding.firstSeenAt).toBeDefined();
+      expect(finding.lastSeenAt).toBeDefined();
+      expect(finding.firstSeenAt).toBe(finding.lastSeenAt);
+      expect(finding.attrsJson).toBe('{"cve":"CVE-2024-1234"}');
+
+      // discovered イベントが finding_events に存在する
+      const events = repo.getEvents(finding.id);
+      expect(events).toHaveLength(1);
+      expect(events[0].eventType).toBe('discovered');
+      expect(events[0].findingId).toBe(finding.id);
+      expect(events[0].runId).toBe(runId1);
+    });
+
+    it('既存更新（re_observed） — same engagement+canonical_key: created=false, last_seen_at updated', () => {
+      // 初回挿入
+      const first = repo.upsert({
+        engagementId,
+        canonicalKey: 'CVE-2024-5678:host:10.0.0.1',
+        title: 'XSS in search',
+        severity: 'high',
+        confidence: 'medium',
+        runId: runId1,
+      });
+      expect(first.created).toBe(true);
+
+      // 同じ engagement + canonical_key で再度 upsert
+      const second = repo.upsert({
+        engagementId,
+        canonicalKey: 'CVE-2024-5678:host:10.0.0.1',
+        title: 'XSS in search (updated)',
+        severity: 'high',
+        confidence: 'high',
+        runId: runId2,
+      });
+
+      expect(second.created).toBe(false);
+      expect(second.finding.id).toBe(first.finding.id);
+      expect(second.finding.lastSeenRunId).toBe(runId2);
+      expect(second.finding.title).toBe('XSS in search (updated)');
+      expect(second.finding.confidence).toBe('high');
+      // firstSeenRunId は変わらない
+      expect(second.finding.firstSeenRunId).toBe(runId1);
+
+      // finding_events に 'discovered' と 're_observed' の2件がある
+      const events = repo.getEvents(first.finding.id);
+      expect(events).toHaveLength(2);
+      const eventTypes = events.map((e) => e.eventType).sort();
+      expect(eventTypes).toEqual(['discovered', 're_observed']);
+      // re_observed イベントには runId2 が設定されている
+      const reObservedEvent = events.find((e) => e.eventType === 're_observed');
+      expect(reObservedEvent?.runId).toBe(runId2);
+    });
+
+    it('異なるengagementでの同じcanonical_key — should create separate findings', () => {
+      // 別のエンゲージメントを作成
+      const engagement2 = engagementRepo.create({ name: 'Second Engagement' });
+
+      const result1 = repo.upsert({
+        engagementId,
+        canonicalKey: 'CVE-2024-9999:host:172.16.0.1',
+        title: 'SSRF in API',
+        severity: 'critical',
+        confidence: 'high',
+      });
+
+      const result2 = repo.upsert({
+        engagementId: engagement2.id,
+        canonicalKey: 'CVE-2024-9999:host:172.16.0.1',
+        title: 'SSRF in API',
+        severity: 'critical',
+        confidence: 'high',
+      });
+
+      // 両方とも新規作成
+      expect(result1.created).toBe(true);
+      expect(result2.created).toBe(true);
+
+      // 異なる Finding ID
+      expect(result1.finding.id).not.toBe(result2.finding.id);
+
+      // 各エンゲージメントに1件ずつ
+      expect(result1.finding.engagementId).toBe(engagementId);
+      expect(result2.finding.engagementId).toBe(engagement2.id);
+    });
+  });
+
+  // =======================================================================
+  // findById()
+  // =======================================================================
+
+  describe('findById()', () => {
+    it('存在するID — returns finding', () => {
+      const { finding: created } = repo.upsert({
+        engagementId,
+        canonicalKey: 'test:findById',
+        title: 'Find Me',
+        severity: 'medium',
+        confidence: 'low',
+      });
+
+      const found = repo.findById(created.id);
+
+      expect(found).toBeDefined();
+      expect(found!.id).toBe(created.id);
+      expect(found!.title).toBe('Find Me');
+      expect(found!.severity).toBe('medium');
+      expect(found!.confidence).toBe('low');
+      expect(found!.engagementId).toBe(engagementId);
+    });
+
+    it('存在しないID — returns undefined', () => {
+      const found = repo.findById(crypto.randomUUID());
+      expect(found).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // findByEngagement()
+  // =======================================================================
+
+  describe('findByEngagement()', () => {
+    it('エンゲージメントフィルタ — returns all findings for engagement', () => {
+      repo.upsert({
+        engagementId,
+        canonicalKey: 'finding-1',
+        title: 'Finding 1',
+        severity: 'high',
+        confidence: 'high',
+      });
+      repo.upsert({
+        engagementId,
+        canonicalKey: 'finding-2',
+        title: 'Finding 2',
+        severity: 'medium',
+        confidence: 'medium',
+      });
+
+      // 別エンゲージメントに Finding を作成（混入しないことを確認）
+      const engagement2 = engagementRepo.create({ name: 'Other' });
+      repo.upsert({
+        engagementId: engagement2.id,
+        canonicalKey: 'finding-3',
+        title: 'Finding 3',
+        severity: 'low',
+        confidence: 'low',
+      });
+
+      const findings = repo.findByEngagement(engagementId);
+      expect(findings).toHaveLength(2);
+      expect(findings.every((f: Finding) => f.engagementId === engagementId)).toBe(true);
+    });
+
+    it('stateフィルタ — filters by state', () => {
+      repo.upsert({
+        engagementId,
+        canonicalKey: 'state-open',
+        title: 'Open Finding',
+        severity: 'high',
+        confidence: 'high',
+      });
+      repo.upsert({
+        engagementId,
+        canonicalKey: 'state-closed',
+        title: 'Closed Finding',
+        severity: 'medium',
+        confidence: 'medium',
+      });
+
+      // 2つ目を closed に変更
+      const allFindings = repo.findByEngagement(engagementId);
+      const closedFinding = allFindings.find((f: Finding) => f.canonicalKey === 'state-closed')!;
+      repo.updateState(closedFinding.id, 'closed', 'Fixed');
+
+      const openFindings = repo.findByEngagement(engagementId, { state: 'open' });
+      expect(openFindings).toHaveLength(1);
+      expect(openFindings[0].canonicalKey).toBe('state-open');
+
+      const closedFindings = repo.findByEngagement(engagementId, { state: 'closed' });
+      expect(closedFindings).toHaveLength(1);
+      expect(closedFindings[0].canonicalKey).toBe('state-closed');
+    });
+
+    it('severityフィルタ — filters by severity', () => {
+      repo.upsert({
+        engagementId,
+        canonicalKey: 'sev-critical',
+        title: 'Critical Finding',
+        severity: 'critical',
+        confidence: 'high',
+      });
+      repo.upsert({
+        engagementId,
+        canonicalKey: 'sev-low',
+        title: 'Low Finding',
+        severity: 'low',
+        confidence: 'low',
+      });
+
+      const criticalFindings = repo.findByEngagement(engagementId, { severity: 'critical' });
+      expect(criticalFindings).toHaveLength(1);
+      expect(criticalFindings[0].severity).toBe('critical');
+
+      const lowFindings = repo.findByEngagement(engagementId, { severity: 'low' });
+      expect(lowFindings).toHaveLength(1);
+      expect(lowFindings[0].severity).toBe('low');
+    });
+  });
+
+  // =======================================================================
+  // updateState()
+  // =======================================================================
+
+  describe('updateState()', () => {
+    it('状態更新 — updates state, state_reason. Auto-creates state_change event', () => {
+      const { finding } = repo.upsert({
+        engagementId,
+        canonicalKey: 'state-change-test',
+        title: 'State Change Target',
+        severity: 'high',
+        confidence: 'high',
+      });
+
+      expect(finding.state).toBe('open');
+
+      const updated = repo.updateState(finding.id, 'closed', 'Verified as false positive');
+
+      expect(updated).toBeDefined();
+      expect(updated!.state).toBe('closed');
+      expect(updated!.stateReason).toBe('Verified as false positive');
+
+      // state_change イベントが追加されている
+      const events = repo.getEvents(finding.id);
+      // discovered + state_change = 2件
+      const stateChangeEvents = events.filter((e: FindingEvent) => e.eventType === 'state_change');
+      expect(stateChangeEvents).toHaveLength(1);
+      expect(JSON.parse(stateChangeEvents[0].beforeJson)).toEqual({ state: 'open' });
+      expect(JSON.parse(stateChangeEvents[0].afterJson)).toEqual({ state: 'closed' });
+    });
+
+    it('存在しないID — returns undefined', () => {
+      const result = repo.updateState(crypto.randomUUID(), 'closed', 'No reason');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // addEvent()
+  // =======================================================================
+
+  describe('addEvent()', () => {
+    it('イベント追加 — manually adds finding_event', () => {
+      const { finding } = repo.upsert({
+        engagementId,
+        canonicalKey: 'event-test',
+        title: 'Event Test',
+        severity: 'medium',
+        confidence: 'medium',
+      });
+
+      const event = repo.addEvent(finding.id, {
+        eventType: 'manual_review',
+        runId: runId1,
+        beforeJson: '{"state":"open"}',
+        afterJson: '{"state":"reviewed"}',
+      });
+
+      expect(event.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(event.findingId).toBe(finding.id);
+      expect(event.eventType).toBe('manual_review');
+      expect(event.runId).toBe(runId1);
+      expect(event.beforeJson).toBe('{"state":"open"}');
+      expect(event.afterJson).toBe('{"state":"reviewed"}');
+      expect(event.createdAt).toBeDefined();
+    });
+  });
+
+  // =======================================================================
+  // getEvents()
+  // =======================================================================
+
+  describe('getEvents()', () => {
+    it('イベント一覧 — returns events ordered by created_at DESC', () => {
+      const { finding } = repo.upsert({
+        engagementId,
+        canonicalKey: 'events-list-test',
+        title: 'Events List Test',
+        severity: 'low',
+        confidence: 'low',
+      });
+
+      // 追加イベントを挿入
+      repo.addEvent(finding.id, {
+        eventType: 'escalated',
+        beforeJson: '{"priority":"low"}',
+        afterJson: '{"priority":"high"}',
+      });
+      repo.addEvent(finding.id, {
+        eventType: 'assigned',
+        afterJson: '{"owner":"analyst-1"}',
+      });
+
+      const events = repo.getEvents(finding.id);
+
+      // discovered + escalated + assigned = 3件
+      expect(events).toHaveLength(3);
+
+      // created_at DESC 順であること（最新が先頭）
+      for (let i = 0; i < events.length - 1; i++) {
+        expect(events[i].createdAt >= events[i + 1].createdAt).toBe(true);
+      }
+    });
+  });
+
+  // =======================================================================
+  // delete()
+  // =======================================================================
+
+  describe('delete()', () => {
+    it('正常削除 — finding + cascaded events deleted', () => {
+      const { finding } = repo.upsert({
+        engagementId,
+        canonicalKey: 'delete-test',
+        title: 'To Be Deleted',
+        severity: 'info',
+        confidence: 'low',
+      });
+
+      // イベントも追加
+      repo.addEvent(finding.id, {
+        eventType: 'manual_note',
+        afterJson: '{"note":"test"}',
+      });
+
+      // 削除前にイベントが存在することを確認
+      expect(repo.getEvents(finding.id)).toHaveLength(2); // discovered + manual_note
+
+      const result = repo.delete(finding.id);
+      expect(result).toBe(true);
+
+      // Finding が取得できない
+      expect(repo.findById(finding.id)).toBeUndefined();
+
+      // CASCADE により finding_events も削除されている
+      const eventsAfter = db
+        .prepare('SELECT id FROM finding_events WHERE finding_id = ?')
+        .all(finding.id);
+      expect(eventsAfter).toHaveLength(0);
+    });
+
+    it('存在しないID — returns false', () => {
+      const result = repo.delete(crypto.randomUUID());
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/tests/db/repository/risk-snapshot-repository.test.ts
+++ b/tests/db/repository/risk-snapshot-repository.test.ts
@@ -92,9 +92,7 @@ describe('RiskSnapshotRepository', () => {
 
       // ID は UUID 形式
       expect(snapshot.id).toBeDefined();
-      expect(snapshot.id).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-      );
+      expect(snapshot.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
 
       // 全フィールドの検証
       expect(snapshot.engagementId).toBe(engagementId);

--- a/tests/db/repository/risk-snapshot-repository.test.ts
+++ b/tests/db/repository/risk-snapshot-repository.test.ts
@@ -18,9 +18,25 @@ function createTestDb(): InstanceType<typeof Database> {
   return db;
 }
 
-/** created_at を制御するためにスリープする小さなヘルパー */
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * created_at を明示的に指定してスナップショットを直接挿入する。
+ * delay() によるフレーキーテストを回避するため。
+ */
+function insertSnapshotWithTimestamp(
+  db: InstanceType<typeof Database>,
+  engagementId: string,
+  score: number,
+  createdAt: string,
+): string {
+  const id = crypto.randomUUID();
+  db.prepare(
+    `INSERT INTO risk_snapshots
+       (id, engagement_id, score, open_critical, open_high, open_medium,
+        open_low, open_info, open_total, attack_path_count, exposed_cred_count,
+        attrs_json, created_at)
+     VALUES (?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, '{}', ?)`,
+  ).run(id, engagementId, score, createdAt);
+  return id;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,7 +118,7 @@ describe('RiskSnapshotRepository', () => {
       expect(found!.score).toBe(85.5);
     });
 
-    it('デフォルト値 — integer fields default to 0, attrsJson to \'{}\'', () => {
+    it("デフォルト値 — integer fields default to 0, attrsJson to '{}'", () => {
       const snapshot = repo.create({
         engagementId,
         score: 50.0,
@@ -159,17 +175,15 @@ describe('RiskSnapshotRepository', () => {
   // =======================================================================
 
   describe('findByEngagement()', () => {
-    it('エンゲージメントフィルタ — returns snapshots ordered by created_at DESC', async () => {
-      // created_at の順序を保証するために明示的にタイムスタンプをずらして挿入
-      const snap1 = repo.create({ engagementId, score: 10.0 });
-      await delay(10);
-      const snap2 = repo.create({ engagementId, score: 20.0 });
-      await delay(10);
-      const snap3 = repo.create({ engagementId, score: 30.0 });
+    it('エンゲージメントフィルタ — returns snapshots ordered by created_at DESC', () => {
+      // 明示的なタイムスタンプで挿入（フレーキーテスト防止）
+      const id1 = insertSnapshotWithTimestamp(db, engagementId, 10.0, '2026-01-01T00:00:00.000Z');
+      const id2 = insertSnapshotWithTimestamp(db, engagementId, 20.0, '2026-01-02T00:00:00.000Z');
+      const id3 = insertSnapshotWithTimestamp(db, engagementId, 30.0, '2026-01-03T00:00:00.000Z');
 
       // 別のエンゲージメントにもスナップショットを追加（フィルタ確認用）
       const otherEngagement = engagementRepo.create({ name: 'Other Engagement' });
-      repo.create({ engagementId: otherEngagement.id, score: 99.0 });
+      insertSnapshotWithTimestamp(db, otherEngagement.id, 99.0, '2026-01-04T00:00:00.000Z');
 
       const snapshots = repo.findByEngagement(engagementId);
 
@@ -177,29 +191,26 @@ describe('RiskSnapshotRepository', () => {
       expect(snapshots).toHaveLength(3);
 
       // created_at DESC 順
-      expect(snapshots[0].id).toBe(snap3.id);
-      expect(snapshots[1].id).toBe(snap2.id);
-      expect(snapshots[2].id).toBe(snap1.id);
+      expect(snapshots[0].id).toBe(id3);
+      expect(snapshots[1].id).toBe(id2);
+      expect(snapshots[2].id).toBe(id1);
 
       // 全て対象エンゲージメントのもの
       expect(snapshots.every((s: RiskSnapshot) => s.engagementId === engagementId)).toBe(true);
     });
 
-    it('limit指定 — respects limit', async () => {
-      repo.create({ engagementId, score: 10.0 });
-      await delay(10);
-      repo.create({ engagementId, score: 20.0 });
-      await delay(10);
-      const snap3 = repo.create({ engagementId, score: 30.0 });
-      await delay(10);
-      const snap4 = repo.create({ engagementId, score: 40.0 });
+    it('limit指定 — respects limit', () => {
+      insertSnapshotWithTimestamp(db, engagementId, 10.0, '2026-01-01T00:00:00.000Z');
+      insertSnapshotWithTimestamp(db, engagementId, 20.0, '2026-01-02T00:00:00.000Z');
+      const id3 = insertSnapshotWithTimestamp(db, engagementId, 30.0, '2026-01-03T00:00:00.000Z');
+      const id4 = insertSnapshotWithTimestamp(db, engagementId, 40.0, '2026-01-04T00:00:00.000Z');
 
       const snapshots = repo.findByEngagement(engagementId, 2);
 
       expect(snapshots).toHaveLength(2);
       // 最新の2件（created_at DESC）
-      expect(snapshots[0].id).toBe(snap4.id);
-      expect(snapshots[1].id).toBe(snap3.id);
+      expect(snapshots[0].id).toBe(id4);
+      expect(snapshots[1].id).toBe(id3);
     });
   });
 
@@ -208,17 +219,20 @@ describe('RiskSnapshotRepository', () => {
   // =======================================================================
 
   describe('latest()', () => {
-    it('最新スナップショット取得 — returns the most recent snapshot for engagement', async () => {
-      repo.create({ engagementId, score: 10.0 });
-      await delay(10);
-      repo.create({ engagementId, score: 20.0 });
-      await delay(10);
-      const newest = repo.create({ engagementId, score: 30.0 });
+    it('最新スナップショット取得 — returns the most recent snapshot for engagement', () => {
+      insertSnapshotWithTimestamp(db, engagementId, 10.0, '2026-01-01T00:00:00.000Z');
+      insertSnapshotWithTimestamp(db, engagementId, 20.0, '2026-01-02T00:00:00.000Z');
+      const newestId = insertSnapshotWithTimestamp(
+        db,
+        engagementId,
+        30.0,
+        '2026-01-03T00:00:00.000Z',
+      );
 
       const latest = repo.latest(engagementId);
 
       expect(latest).toBeDefined();
-      expect(latest!.id).toBe(newest.id);
+      expect(latest!.id).toBe(newestId);
       expect(latest!.score).toBe(30.0);
     });
 

--- a/tests/db/repository/risk-snapshot-repository.test.ts
+++ b/tests/db/repository/risk-snapshot-repository.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { RiskSnapshotRepository } from '../../../src/db/repository/risk-snapshot-repository.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+import { RunRepository } from '../../../src/db/repository/run-repository.js';
+import type { RiskSnapshot } from '../../../src/types/operational.js';
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+/** テスト用 :memory: DB を作成しマイグレーション済みで返す */
+function createTestDb(): InstanceType<typeof Database> {
+  const db = new Database(':memory:');
+  migrateDatabase(db);
+  return db;
+}
+
+/** created_at を制御するためにスリープする小さなヘルパー */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+describe('RiskSnapshotRepository', () => {
+  let db: InstanceType<typeof Database>;
+  let repo: RiskSnapshotRepository;
+  let engagementRepo: EngagementRepository;
+  let runRepo: RunRepository;
+  let engagementId: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new RiskSnapshotRepository(db);
+    engagementRepo = new EngagementRepository(db);
+    runRepo = new RunRepository(db);
+
+    // 全テストで使う共通エンゲージメントを作成
+    const engagement = engagementRepo.create({ name: 'Test Engagement' });
+    engagementId = engagement.id;
+  });
+
+  // =======================================================================
+  // create()
+  // =======================================================================
+
+  describe('create()', () => {
+    it('基本作成 — creates snapshot with all fields verified', () => {
+      // run_id の FK 制約を満たすために実際の Run を作成
+      const run = runRepo.create({
+        engagementId,
+        triggerKind: 'manual',
+        status: 'running',
+      });
+
+      const snapshot = repo.create({
+        engagementId,
+        runId: run.id,
+        score: 85.5,
+        openCritical: 2,
+        openHigh: 5,
+        openMedium: 10,
+        openLow: 20,
+        openInfo: 3,
+        openTotal: 40,
+        attackPathCount: 7,
+        exposedCredCount: 1,
+        modelVersion: 'v1.0',
+        attrsJson: '{"custom":"data"}',
+      });
+
+      // ID は UUID 形式
+      expect(snapshot.id).toBeDefined();
+      expect(snapshot.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+
+      // 全フィールドの検証
+      expect(snapshot.engagementId).toBe(engagementId);
+      expect(snapshot.runId).toBeDefined();
+      expect(snapshot.score).toBe(85.5);
+      expect(snapshot.openCritical).toBe(2);
+      expect(snapshot.openHigh).toBe(5);
+      expect(snapshot.openMedium).toBe(10);
+      expect(snapshot.openLow).toBe(20);
+      expect(snapshot.openInfo).toBe(3);
+      expect(snapshot.openTotal).toBe(40);
+      expect(snapshot.attackPathCount).toBe(7);
+      expect(snapshot.exposedCredCount).toBe(1);
+      expect(snapshot.modelVersion).toBe('v1.0');
+      expect(snapshot.attrsJson).toBe('{"custom":"data"}');
+      expect(snapshot.createdAt).toBeDefined();
+
+      // DB に実際に保存されていることを確認
+      const found = repo.findById(snapshot.id);
+      expect(found).toBeDefined();
+      expect(found!.score).toBe(85.5);
+    });
+
+    it('デフォルト値 — integer fields default to 0, attrsJson to \'{}\'', () => {
+      const snapshot = repo.create({
+        engagementId,
+        score: 50.0,
+      });
+
+      expect(snapshot.openCritical).toBe(0);
+      expect(snapshot.openHigh).toBe(0);
+      expect(snapshot.openMedium).toBe(0);
+      expect(snapshot.openLow).toBe(0);
+      expect(snapshot.openInfo).toBe(0);
+      expect(snapshot.openTotal).toBe(0);
+      expect(snapshot.attackPathCount).toBe(0);
+      expect(snapshot.exposedCredCount).toBe(0);
+      expect(snapshot.modelVersion).toBeUndefined();
+      expect(snapshot.runId).toBeUndefined();
+      expect(snapshot.attrsJson).toBe('{}');
+    });
+  });
+
+  // =======================================================================
+  // findById()
+  // =======================================================================
+
+  describe('findById()', () => {
+    it('存在するID — returns the snapshot', () => {
+      const created = repo.create({
+        engagementId,
+        score: 72.3,
+        openCritical: 1,
+        openHigh: 3,
+        modelVersion: 'v2.0',
+      });
+
+      const found = repo.findById(created.id);
+
+      expect(found).toBeDefined();
+      expect(found!.id).toBe(created.id);
+      expect(found!.engagementId).toBe(engagementId);
+      expect(found!.score).toBe(72.3);
+      expect(found!.openCritical).toBe(1);
+      expect(found!.openHigh).toBe(3);
+      expect(found!.modelVersion).toBe('v2.0');
+      expect(found!.createdAt).toBe(created.createdAt);
+    });
+
+    it('存在しないID — returns undefined', () => {
+      const found = repo.findById(crypto.randomUUID());
+      expect(found).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // findByEngagement()
+  // =======================================================================
+
+  describe('findByEngagement()', () => {
+    it('エンゲージメントフィルタ — returns snapshots ordered by created_at DESC', async () => {
+      // created_at の順序を保証するために明示的にタイムスタンプをずらして挿入
+      const snap1 = repo.create({ engagementId, score: 10.0 });
+      await delay(10);
+      const snap2 = repo.create({ engagementId, score: 20.0 });
+      await delay(10);
+      const snap3 = repo.create({ engagementId, score: 30.0 });
+
+      // 別のエンゲージメントにもスナップショットを追加（フィルタ確認用）
+      const otherEngagement = engagementRepo.create({ name: 'Other Engagement' });
+      repo.create({ engagementId: otherEngagement.id, score: 99.0 });
+
+      const snapshots = repo.findByEngagement(engagementId);
+
+      // 対象エンゲージメントのスナップショットのみ
+      expect(snapshots).toHaveLength(3);
+
+      // created_at DESC 順
+      expect(snapshots[0].id).toBe(snap3.id);
+      expect(snapshots[1].id).toBe(snap2.id);
+      expect(snapshots[2].id).toBe(snap1.id);
+
+      // 全て対象エンゲージメントのもの
+      expect(snapshots.every((s: RiskSnapshot) => s.engagementId === engagementId)).toBe(true);
+    });
+
+    it('limit指定 — respects limit', async () => {
+      repo.create({ engagementId, score: 10.0 });
+      await delay(10);
+      repo.create({ engagementId, score: 20.0 });
+      await delay(10);
+      const snap3 = repo.create({ engagementId, score: 30.0 });
+      await delay(10);
+      const snap4 = repo.create({ engagementId, score: 40.0 });
+
+      const snapshots = repo.findByEngagement(engagementId, 2);
+
+      expect(snapshots).toHaveLength(2);
+      // 最新の2件（created_at DESC）
+      expect(snapshots[0].id).toBe(snap4.id);
+      expect(snapshots[1].id).toBe(snap3.id);
+    });
+  });
+
+  // =======================================================================
+  // latest()
+  // =======================================================================
+
+  describe('latest()', () => {
+    it('最新スナップショット取得 — returns the most recent snapshot for engagement', async () => {
+      repo.create({ engagementId, score: 10.0 });
+      await delay(10);
+      repo.create({ engagementId, score: 20.0 });
+      await delay(10);
+      const newest = repo.create({ engagementId, score: 30.0 });
+
+      const latest = repo.latest(engagementId);
+
+      expect(latest).toBeDefined();
+      expect(latest!.id).toBe(newest.id);
+      expect(latest!.score).toBe(30.0);
+    });
+
+    it('スナップショットなし — returns undefined when no snapshots exist', () => {
+      const latest = repo.latest(engagementId);
+      expect(latest).toBeUndefined();
+    });
+  });
+});

--- a/tests/db/repository/run-repository.test.ts
+++ b/tests/db/repository/run-repository.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { RunRepository } from '../../../src/db/repository/run-repository.js';
+import type { Run } from '../../../src/types/operational.js';
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+/** テスト用 :memory: DB を作成しマイグレーション済みで返す */
+function createTestDb(): InstanceType<typeof Database> {
+  const db = new Database(':memory:');
+  migrateDatabase(db);
+  return db;
+}
+
+/** テスト用 engagement レコードを挿入し id を返す */
+function insertTestEngagement(db: InstanceType<typeof Database>, name?: string): string {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO engagements (id, name, environment, scope_json, policy_json, status, created_at, updated_at)
+     VALUES (?, ?, 'stg', '{}', '{}', 'active', ?, ?)`,
+  ).run(id, name ?? 'Test Engagement', now, now);
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+describe('RunRepository', () => {
+  let db: InstanceType<typeof Database>;
+  let repo: RunRepository;
+  let engagementId: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new RunRepository(db);
+    engagementId = insertTestEngagement(db);
+  });
+
+  // =======================================================================
+  // create()
+  // =======================================================================
+
+  describe('create()', () => {
+    it('基本作成 — creates a run with all fields verified', () => {
+      const run = repo.create({
+        engagementId,
+        triggerKind: 'manual',
+        triggerRef: 'user:admin',
+        status: 'running',
+      });
+
+      expect(run.id).toBeDefined();
+      expect(run.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(run.engagementId).toBe(engagementId);
+      expect(run.triggerKind).toBe('manual');
+      expect(run.triggerRef).toBe('user:admin');
+      expect(run.status).toBe('running');
+      expect(run.startedAt).toBeDefined();
+      expect(run.summaryJson).toBe('{}');
+      expect(run.createdAt).toBeDefined();
+    });
+
+    it('デフォルト値 — summaryJson defaults to {}, started_at/finished_at null when pending', () => {
+      const run = repo.create({
+        engagementId,
+        triggerKind: 'scheduled',
+        status: 'pending',
+      });
+
+      expect(run.summaryJson).toBe('{}');
+      expect(run.startedAt).toBeUndefined();
+      expect(run.finishedAt).toBeUndefined();
+      expect(run.triggerRef).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // findById()
+  // =======================================================================
+
+  describe('findById()', () => {
+    it('存在するID — returns the run', () => {
+      const created = repo.create({
+        engagementId,
+        triggerKind: 'manual',
+        status: 'running',
+      });
+
+      const found = repo.findById(created.id);
+
+      expect(found).toBeDefined();
+      expect(found!.id).toBe(created.id);
+      expect(found!.engagementId).toBe(engagementId);
+      expect(found!.triggerKind).toBe('manual');
+      expect(found!.status).toBe('running');
+      expect(found!.startedAt).toBeDefined();
+      expect(found!.summaryJson).toBe('{}');
+      expect(found!.createdAt).toBeDefined();
+    });
+
+    it('存在しないID — returns undefined', () => {
+      const found = repo.findById(crypto.randomUUID());
+      expect(found).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // findByEngagement()
+  // =======================================================================
+
+  describe('findByEngagement()', () => {
+    it('エンゲージメントフィルタ — returns only runs for given engagement, ordered by created_at DESC', () => {
+      const engagementId2 = insertTestEngagement(db, 'Other Engagement');
+
+      // engagement 1 に 2 件作成（created_at に明確な時間差を設ける）
+      const runId1 = crypto.randomUUID();
+      const runId2 = crypto.randomUUID();
+
+      db.prepare(
+        `INSERT INTO runs (id, engagement_id, trigger_kind, status, summary_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(runId1, engagementId, 'manual', 'pending', '{}', '2026-01-01T00:00:00.000Z');
+
+      db.prepare(
+        `INSERT INTO runs (id, engagement_id, trigger_kind, status, summary_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(runId2, engagementId, 'scheduled', 'running', '{}', '2026-01-02T00:00:00.000Z');
+
+      // engagement 2 に 1 件作成
+      repo.create({
+        engagementId: engagementId2,
+        triggerKind: 'manual',
+        status: 'pending',
+      });
+
+      const runs = repo.findByEngagement(engagementId);
+
+      expect(runs).toHaveLength(2);
+      expect(runs.every((r: Run) => r.engagementId === engagementId)).toBe(true);
+
+      // created_at DESC 順：runId2 が先（より新しい）
+      expect(runs[0].id).toBe(runId2);
+      expect(runs[1].id).toBe(runId1);
+    });
+
+    it('limit指定 — respects the limit parameter', () => {
+      // 5 件作成
+      for (let i = 0; i < 5; i++) {
+        repo.create({
+          engagementId,
+          triggerKind: 'manual',
+          status: 'pending',
+        });
+      }
+
+      const limited = repo.findByEngagement(engagementId, 3);
+      expect(limited).toHaveLength(3);
+
+      const all = repo.findByEngagement(engagementId);
+      expect(all).toHaveLength(5);
+    });
+  });
+
+  // =======================================================================
+  // findByStatus()
+  // =======================================================================
+
+  describe('findByStatus()', () => {
+    it('ステータスフィルタ — finds only matching status', () => {
+      repo.create({ engagementId, triggerKind: 'manual', status: 'running' });
+      repo.create({ engagementId, triggerKind: 'manual', status: 'running' });
+      repo.create({ engagementId, triggerKind: 'manual', status: 'pending' });
+      repo.create({ engagementId, triggerKind: 'scheduled', status: 'succeeded' });
+
+      const running = repo.findByStatus('running');
+      const pending = repo.findByStatus('pending');
+      const succeeded = repo.findByStatus('succeeded');
+
+      expect(running).toHaveLength(2);
+      expect(running.every((r: Run) => r.status === 'running')).toBe(true);
+      expect(pending).toHaveLength(1);
+      expect(succeeded).toHaveLength(1);
+    });
+  });
+
+  // =======================================================================
+  // updateStatus()
+  // =======================================================================
+
+  describe('updateStatus()', () => {
+    it('running → succeeded — updates status, auto-sets finished_at', () => {
+      const run = repo.create({
+        engagementId,
+        triggerKind: 'manual',
+        status: 'running',
+      });
+
+      const updated = repo.updateStatus(run.id, 'succeeded');
+
+      expect(updated).toBeDefined();
+      expect(updated!.status).toBe('succeeded');
+      expect(updated!.finishedAt).toBeDefined();
+    });
+
+    it('running → failed — updates status, auto-sets finished_at', () => {
+      const run = repo.create({
+        engagementId,
+        triggerKind: 'manual',
+        status: 'running',
+      });
+
+      const updated = repo.updateStatus(run.id, 'failed');
+
+      expect(updated).toBeDefined();
+      expect(updated!.status).toBe('failed');
+      expect(updated!.finishedAt).toBeDefined();
+    });
+
+    it('pending → running — does NOT set finished_at', () => {
+      const run = repo.create({
+        engagementId,
+        triggerKind: 'manual',
+        status: 'pending',
+      });
+
+      expect(run.startedAt).toBeUndefined();
+
+      const updated = repo.updateStatus(run.id, 'running');
+
+      expect(updated).toBeDefined();
+      expect(updated!.status).toBe('running');
+      expect(updated!.startedAt).toBeDefined();
+      expect(updated!.finishedAt).toBeUndefined();
+    });
+
+    it('summaryJson更新 — optionally updates summaryJson', () => {
+      const run = repo.create({
+        engagementId,
+        triggerKind: 'manual',
+        status: 'running',
+      });
+
+      const summary = '{"hosts_scanned":42,"vulns_found":7}';
+      const updated = repo.updateStatus(run.id, 'succeeded', summary);
+
+      expect(updated).toBeDefined();
+      expect(updated!.summaryJson).toBe(summary);
+      expect(updated!.status).toBe('succeeded');
+    });
+
+    it('存在しないID — returns undefined', () => {
+      const result = repo.updateStatus(crypto.randomUUID(), 'succeeded');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // =======================================================================
+  // delete()
+  // =======================================================================
+
+  describe('delete()', () => {
+    it('正常削除 — returns true, run is gone', () => {
+      const created = repo.create({
+        engagementId,
+        triggerKind: 'manual',
+        status: 'running',
+      });
+
+      const result = repo.delete(created.id);
+      expect(result).toBe(true);
+
+      const found = repo.findById(created.id);
+      expect(found).toBeUndefined();
+    });
+
+    it('存在しないID — returns false', () => {
+      const result = repo.delete(crypto.randomUUID());
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/tests/db/repository/run-repository.test.ts
+++ b/tests/db/repository/run-repository.test.ts
@@ -56,9 +56,7 @@ describe('RunRepository', () => {
       });
 
       expect(run.id).toBeDefined();
-      expect(run.id).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-      );
+      expect(run.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(run.engagementId).toBe(engagementId);
       expect(run.triggerKind).toBe('manual');
       expect(run.triggerRef).toBe('user:admin');

--- a/tests/db/repository/technique-doc-repository.test.ts
+++ b/tests/db/repository/technique-doc-repository.test.ts
@@ -231,18 +231,18 @@ describe('TechniqueDocRepository', () => {
     const count = repo.index(docs);
     expect(count).toBe(2);
 
-    const row = db
-      .prepare('SELECT file_mtime FROM technique_docs LIMIT 1')
-      .get() as { file_mtime: string | null };
+    const row = db.prepare('SELECT file_mtime FROM technique_docs LIMIT 1').get() as {
+      file_mtime: string | null;
+    };
     expect(row.file_mtime).toBe('2024-06-15T12:00:00.000Z');
   });
 
   it('index — fileMtime 省略時は NULL になる', () => {
     repo.index([makeDoc()]);
 
-    const row = db
-      .prepare('SELECT file_mtime FROM technique_docs LIMIT 1')
-      .get() as { file_mtime: string | null };
+    const row = db.prepare('SELECT file_mtime FROM technique_docs LIMIT 1').get() as {
+      file_mtime: string | null;
+    };
     expect(row.file_mtime).toBeNull();
   });
 

--- a/tests/engine/git-ops.test.ts
+++ b/tests/engine/git-ops.test.ts
@@ -2,11 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import {
-  isGitAvailable,
-  cloneHacktricks,
-  pullHacktricks,
-} from '../../src/engine/git-ops.js';
+import { isGitAvailable, cloneHacktricks, pullHacktricks } from '../../src/engine/git-ops.js';
 
 // =========================================================
 // isGitAvailable
@@ -26,7 +22,13 @@ describe('isGitAvailable', () => {
 
 describe('cloneHacktricks', () => {
   it('親ディレクトリが存在しない場合は clone_failed を返す', async () => {
-    const nonExistentDir = path.join(os.tmpdir(), 'sonobat-nonexistent-' + Date.now(), 'deep', 'nested', 'hacktricks');
+    const nonExistentDir = path.join(
+      os.tmpdir(),
+      'sonobat-nonexistent-' + Date.now(),
+      'deep',
+      'nested',
+      'hacktricks',
+    );
     const result = await cloneHacktricks(nonExistentDir);
 
     expect(result.ok).toBe(false);

--- a/tests/engine/indexer.test.ts
+++ b/tests/engine/indexer.test.ts
@@ -308,7 +308,10 @@ describe('indexHacktricks — 増分インデックス', () => {
     // 少し待ってから書き込むことで mtime を確実に変える
     const filePath = path.join(tmpDir, 'web', 'sqli.md');
     const futureTime = new Date(Date.now() + 2000);
-    fs.writeFileSync(filePath, '# SQLi\n\nAdvanced SQL injection techniques.\n\n## UNION Attack\n\nUNION-based injection.');
+    fs.writeFileSync(
+      filePath,
+      '# SQLi\n\nAdvanced SQL injection techniques.\n\n## UNION Attack\n\nUNION-based injection.',
+    );
     fs.utimesSync(filePath, futureTime, futureTime);
 
     const result2 = indexHacktricks(db, tmpDir);

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -44,7 +44,7 @@ describe('MCP Server', () => {
   // ツール登録確認
   // =========================================================
 
-  it('6 ツールが登録されている', async () => {
+  it('8 ツールが登録されている', async () => {
     const result = await client.listTools();
     const toolNames = result.tools.map((t) => t.name).sort();
 
@@ -54,7 +54,9 @@ describe('MCP Server', () => {
     expect(toolNames).toContain('propose');
     expect(toolNames).toContain('search_kb');
     expect(toolNames).toContain('index_kb');
-    expect(result.tools.length).toBe(6);
+    expect(toolNames).toContain('ops');
+    expect(toolNames).toContain('findings');
+    expect(result.tools.length).toBe(8);
   });
 
   it('リソースが登録されている', async () => {

--- a/tests/mcp/tools/findings.test.ts
+++ b/tests/mcp/tools/findings.test.ts
@@ -1,0 +1,487 @@
+/**
+ * sonobat — MCP Findings Tool テスト
+ *
+ * InMemoryTransport で MCP サーバーとクライアントをインメモリ接続し、
+ * findings ツールの全 9 アクションを検証する。
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { registerFindingsTools } from '../../../src/mcp/tools/findings.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+type TextContent = Array<{ type: string; text: string }>;
+
+/** MCP ツール呼び出し結果からテキストをパースして返す */
+function parseResponse<T>(result: { content: unknown }): T {
+  const content = result.content as TextContent;
+  return JSON.parse(content[0].text) as T;
+}
+
+/** MCP ツール呼び出し結果からテキストを返す */
+function getText(result: { content: unknown }): string {
+  const content = result.content as TextContent;
+  return content[0].text;
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+describe('MCP Findings Tool', () => {
+  let db: InstanceType<typeof Database>;
+  let client: Client;
+  let engagementId: string;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    migrateDatabase(db);
+
+    // FK 制約のために engagement を作成
+    const engagementRepo = new EngagementRepository(db);
+    const engagement = engagementRepo.create({ name: 'Findings Test' });
+    engagementId = engagement.id;
+
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    registerFindingsTools(server, db);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+
+    client = new Client({ name: 'test-client', version: '0.0.0' });
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  /** findings ツールを呼び出すヘルパー */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- MCP SDK callTool returns a complex union type
+  async function callTool(args: Record<string, unknown>): Promise<any> {
+    return await client.callTool({ name: 'findings', arguments: args });
+  }
+
+  // =========================================================
+  // Finding アクション
+  // =========================================================
+
+  describe('Finding', () => {
+    it('upsert_finding — 新規作成', async () => {
+      const result = await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'sqli:login-form',
+        title: 'SQL Injection in Login Form',
+        severity: 'critical',
+        confidence: 'high',
+      });
+      const data = parseResponse<{
+        id: string;
+        canonicalKey: string;
+        title: string;
+        severity: string;
+        confidence: string;
+        created: boolean;
+      }>(result);
+      expect(data.created).toBe(true);
+      expect(data.id).toBeDefined();
+      expect(data.canonicalKey).toBe('sqli:login-form');
+      expect(data.title).toBe('SQL Injection in Login Form');
+      expect(data.severity).toBe('critical');
+      expect(data.confidence).toBe('high');
+    });
+
+    it('upsert_finding — 既存更新', async () => {
+      // 1回目: 新規作成
+      const firstResult = await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'xss:search',
+        title: 'XSS in Search',
+        severity: 'high',
+        confidence: 'medium',
+      });
+      const first = parseResponse<{ id: string; created: boolean }>(firstResult);
+      expect(first.created).toBe(true);
+
+      // 2回目: 同じ canonical_key で更新
+      const secondResult = await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'xss:search',
+        title: 'XSS in Search (updated)',
+        severity: 'critical',
+        confidence: 'high',
+      });
+      const second = parseResponse<{
+        id: string;
+        created: boolean;
+        title: string;
+        severity: string;
+      }>(secondResult);
+      expect(second.created).toBe(false);
+      expect(second.id).toBe(first.id);
+    });
+
+    it('get_finding — 存在するID', async () => {
+      // 事前に finding を作成
+      const createResult = await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'idor:user-api',
+        title: 'IDOR in User API',
+        severity: 'high',
+        confidence: 'high',
+      });
+      const { id } = parseResponse<{ id: string }>(createResult);
+
+      // get_finding
+      const getResult = await callTool({ action: 'get_finding', id });
+      const finding = parseResponse<{ id: string; title: string; canonicalKey: string }>(
+        getResult,
+      );
+      expect(finding.id).toBe(id);
+      expect(finding.title).toBe('IDOR in User API');
+      expect(finding.canonicalKey).toBe('idor:user-api');
+    });
+
+    it('get_finding — 存在しないID', async () => {
+      const result = await callTool({
+        action: 'get_finding',
+        id: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('not found');
+    });
+
+    it('list_findings — エンゲージメントフィルタ', async () => {
+      // finding を2つ作成
+      await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'sqli:login',
+        title: 'SQLi Login',
+        severity: 'critical',
+        confidence: 'high',
+      });
+      await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'xss:comment',
+        title: 'XSS Comment',
+        severity: 'medium',
+        confidence: 'medium',
+      });
+
+      const result = await callTool({
+        action: 'list_findings',
+        engagementId,
+      });
+      const findings = parseResponse<Array<{ id: string }>>(result);
+      expect(findings).toHaveLength(2);
+    });
+
+    it('list_findings — stateフィルタ', async () => {
+      // finding を作成（デフォルト state は open と想定）
+      await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'sqli:search',
+        title: 'SQLi Search',
+        severity: 'high',
+        confidence: 'high',
+      });
+      await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'info:leak',
+        title: 'Info Leak',
+        severity: 'low',
+        confidence: 'medium',
+        state: 'resolved',
+      });
+
+      const result = await callTool({
+        action: 'list_findings',
+        engagementId,
+        state: 'open',
+      });
+      const findings = parseResponse<Array<{ canonicalKey: string }>>(result);
+      expect(findings).toHaveLength(1);
+      expect(findings[0].canonicalKey).toBe('sqli:search');
+    });
+
+    it('update_finding_state — 状態更新', async () => {
+      // finding を作成
+      const createResult = await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'ssrf:internal',
+        title: 'SSRF to Internal',
+        severity: 'critical',
+        confidence: 'high',
+      });
+      const { id } = parseResponse<{ id: string }>(createResult);
+
+      // 状態を更新
+      const updateResult = await callTool({
+        action: 'update_finding_state',
+        id,
+        state: 'resolved',
+        stateReason: 'Patched in v2.1.0',
+      });
+      const updated = parseResponse<{ state: string; stateReason: string }>(updateResult);
+      expect(updated.state).toBe('resolved');
+      expect(updated.stateReason).toBe('Patched in v2.1.0');
+    });
+
+    it('list_finding_events — イベント一覧', async () => {
+      // finding を作成 (upsert で自動的にイベントが記録される想定)
+      const createResult = await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'rce:upload',
+        title: 'RCE via File Upload',
+        severity: 'critical',
+        confidence: 'high',
+      });
+      const { id } = parseResponse<{ id: string }>(createResult);
+
+      const eventsResult = await callTool({
+        action: 'list_finding_events',
+        findingId: id,
+      });
+      const events = parseResponse<Array<{ id: string; eventType: string }>>(eventsResult);
+      // upsert (created) should produce at least one event
+      expect(events.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // =========================================================
+  // RiskSnapshot アクション
+  // =========================================================
+
+  describe('RiskSnapshot', () => {
+    it('create_risk_snapshot — 基本作成', async () => {
+      const result = await callTool({
+        action: 'create_risk_snapshot',
+        engagementId,
+        score: 72.5,
+        openCritical: 2,
+        openHigh: 5,
+        openMedium: 10,
+        openLow: 3,
+        openInfo: 1,
+        openTotal: 21,
+      });
+      const snapshot = parseResponse<{
+        id: string;
+        engagementId: string;
+        score: number;
+        openCritical: number;
+        openTotal: number;
+      }>(result);
+      expect(snapshot.id).toBeDefined();
+      expect(snapshot.engagementId).toBe(engagementId);
+      expect(snapshot.score).toBe(72.5);
+      expect(snapshot.openCritical).toBe(2);
+      expect(snapshot.openTotal).toBe(21);
+    });
+
+    it('get_risk_snapshot — 存在するID', async () => {
+      const createResult = await callTool({
+        action: 'create_risk_snapshot',
+        engagementId,
+        score: 50.0,
+      });
+      const { id } = parseResponse<{ id: string }>(createResult);
+
+      const getResult = await callTool({ action: 'get_risk_snapshot', id });
+      const snapshot = parseResponse<{ id: string; score: number }>(getResult);
+      expect(snapshot.id).toBe(id);
+      expect(snapshot.score).toBe(50.0);
+    });
+
+    it('get_risk_snapshot — 存在しないID', async () => {
+      const result = await callTool({
+        action: 'get_risk_snapshot',
+        id: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('not found');
+    });
+
+    it('list_risk_snapshots — エンゲージメントフィルタ', async () => {
+      await callTool({
+        action: 'create_risk_snapshot',
+        engagementId,
+        score: 30.0,
+      });
+      await callTool({
+        action: 'create_risk_snapshot',
+        engagementId,
+        score: 60.0,
+      });
+
+      const result = await callTool({
+        action: 'list_risk_snapshots',
+        engagementId,
+      });
+      const snapshots = parseResponse<Array<{ id: string }>>(result);
+      expect(snapshots).toHaveLength(2);
+    });
+
+    it('latest_risk_snapshot — 最新取得', async () => {
+      await callTool({
+        action: 'create_risk_snapshot',
+        engagementId,
+        score: 30.0,
+      });
+      await callTool({
+        action: 'create_risk_snapshot',
+        engagementId,
+        score: 85.0,
+      });
+
+      const result = await callTool({
+        action: 'latest_risk_snapshot',
+        engagementId,
+      });
+      const snapshot = parseResponse<{ score: number }>(result);
+      expect(snapshot.score).toBe(85.0);
+    });
+
+    it('latest_risk_snapshot — スナップショットが存在しない場合', async () => {
+      const result = await callTool({
+        action: 'latest_risk_snapshot',
+        engagementId,
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('No risk snapshot found');
+    });
+  });
+
+  // =========================================================
+  // バリデーションエラー
+  // =========================================================
+
+  describe('Validation', () => {
+    it('missing required param — list_findings で engagementId 未指定', async () => {
+      const result = await callTool({ action: 'list_findings' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('engagementId parameter is required');
+    });
+
+    it('missing required param — upsert_finding で必須パラメータ不足', async () => {
+      const r1 = await callTool({ action: 'upsert_finding' });
+      expect(r1.isError).toBe(true);
+      expect(getText(r1)).toContain('engagementId');
+
+      const r2 = await callTool({ action: 'upsert_finding', engagementId });
+      expect(r2.isError).toBe(true);
+      expect(getText(r2)).toContain('canonicalKey');
+
+      const r3 = await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'test:key',
+      });
+      expect(r3.isError).toBe(true);
+      expect(getText(r3)).toContain('title');
+
+      const r4 = await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'test:key',
+        title: 'Test',
+      });
+      expect(r4.isError).toBe(true);
+      expect(getText(r4)).toContain('severity');
+
+      const r5 = await callTool({
+        action: 'upsert_finding',
+        engagementId,
+        canonicalKey: 'test:key',
+        title: 'Test',
+        severity: 'high',
+      });
+      expect(r5.isError).toBe(true);
+      expect(getText(r5)).toContain('confidence');
+    });
+
+    it('missing required param — get_finding で id 未指定', async () => {
+      const result = await callTool({ action: 'get_finding' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('id parameter is required');
+    });
+
+    it('missing required param — update_finding_state で id/state 未指定', async () => {
+      const r1 = await callTool({ action: 'update_finding_state' });
+      expect(r1.isError).toBe(true);
+      expect(getText(r1)).toContain('id');
+
+      const r2 = await callTool({
+        action: 'update_finding_state',
+        id: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(r2.isError).toBe(true);
+      expect(getText(r2)).toContain('state');
+    });
+
+    it('missing required param — list_finding_events で findingId 未指定', async () => {
+      const result = await callTool({ action: 'list_finding_events' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('findingId parameter is required');
+    });
+
+    it('missing required param — create_risk_snapshot で engagementId/score 未指定', async () => {
+      const r1 = await callTool({ action: 'create_risk_snapshot' });
+      expect(r1.isError).toBe(true);
+      expect(getText(r1)).toContain('engagementId');
+
+      const r2 = await callTool({
+        action: 'create_risk_snapshot',
+        engagementId,
+      });
+      expect(r2.isError).toBe(true);
+      expect(getText(r2)).toContain('score');
+    });
+
+    it('missing required param — get_risk_snapshot で id 未指定', async () => {
+      const result = await callTool({ action: 'get_risk_snapshot' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('id parameter is required');
+    });
+
+    it('missing required param — list_risk_snapshots で engagementId 未指定', async () => {
+      const result = await callTool({ action: 'list_risk_snapshots' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('engagementId parameter is required');
+    });
+
+    it('missing required param — latest_risk_snapshot で engagementId 未指定', async () => {
+      const result = await callTool({ action: 'latest_risk_snapshot' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('engagementId parameter is required');
+    });
+  });
+
+  // =========================================================
+  // ツール登録確認
+  // =========================================================
+
+  it('findings ツールが登録されている', async () => {
+    const result = await client.listTools();
+    const toolNames = result.tools.map((t) => t.name);
+    expect(toolNames).toContain('findings');
+  });
+});

--- a/tests/mcp/tools/findings.test.ts
+++ b/tests/mcp/tools/findings.test.ts
@@ -146,9 +146,7 @@ describe('MCP Findings Tool', () => {
 
       // get_finding
       const getResult = await callTool({ action: 'get_finding', id });
-      const finding = parseResponse<{ id: string; title: string; canonicalKey: string }>(
-        getResult,
-      );
+      const finding = parseResponse<{ id: string; title: string; canonicalKey: string }>(getResult);
       expect(finding.id).toBe(id);
       expect(finding.title).toBe('IDOR in User API');
       expect(finding.canonicalKey).toBe('idor:user-api');

--- a/tests/mcp/tools/ops.test.ts
+++ b/tests/mcp/tools/ops.test.ts
@@ -1,0 +1,627 @@
+/**
+ * sonobat — MCP Ops Tool テスト
+ *
+ * InMemoryTransport で MCP サーバーとクライアントをインメモリ接続し、
+ * ops ツールの全 17 アクションを検証する。
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { registerOpsTools } from '../../../src/mcp/tools/ops.js';
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+type TextContent = Array<{ type: string; text: string }>;
+
+/** MCP ツール呼び出し結果からテキストをパースして返す */
+function parseResult<T>(result: { content: unknown }): T {
+  const content = result.content as TextContent;
+  return JSON.parse(content[0].text) as T;
+}
+
+/** MCP ツール呼び出し結果からテキストを返す */
+function getText(result: { content: unknown }): string {
+  const content = result.content as TextContent;
+  return content[0].text;
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+describe('MCP Ops Tool', () => {
+  let db: InstanceType<typeof Database>;
+  let client: Client;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    migrateDatabase(db);
+
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    registerOpsTools(server, db);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+
+    client = new Client({ name: 'test-client', version: '0.0.0' });
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  /** ops ツールを呼び出すヘルパー */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- MCP SDK callTool returns a complex union type
+  async function callOps(args: Record<string, unknown>): Promise<any> {
+    return await client.callTool({ name: 'ops', arguments: args });
+  }
+
+  // =========================================================
+  // Engagement アクション
+  // =========================================================
+
+  describe('Engagement', () => {
+    it('create_engagement → list_engagements → get_engagement — フルサイクル', async () => {
+      // create
+      const createResult = await callOps({
+        action: 'create_engagement',
+        name: 'Test Engagement',
+        environment: 'prod',
+      });
+      const created = parseResult<{ id: string; name: string; environment: string }>(
+        createResult,
+      );
+      expect(created.name).toBe('Test Engagement');
+      expect(created.environment).toBe('prod');
+      expect(created.id).toBeDefined();
+
+      // list
+      const listResult = await callOps({ action: 'list_engagements' });
+      const engagements = parseResult<Array<{ id: string }>>(listResult);
+      expect(engagements).toHaveLength(1);
+      expect(engagements[0].id).toBe(created.id);
+
+      // get
+      const getResult = await callOps({ action: 'get_engagement', id: created.id });
+      const fetched = parseResult<{ id: string; name: string }>(getResult);
+      expect(fetched.id).toBe(created.id);
+      expect(fetched.name).toBe('Test Engagement');
+    });
+
+    it('create_engagement — デフォルト値が設定される', async () => {
+      const result = await callOps({ action: 'create_engagement', name: 'Defaults Test' });
+      const eng = parseResult<{
+        environment: string;
+        scopeJson: string;
+        policyJson: string;
+        status: string;
+      }>(result);
+      expect(eng.environment).toBe('stg');
+      expect(eng.scopeJson).toBe('{}');
+      expect(eng.policyJson).toBe('{}');
+      expect(eng.status).toBe('active');
+    });
+
+    it('create_engagement — name 未指定でエラー', async () => {
+      const result = await callOps({ action: 'create_engagement' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('name parameter is required');
+    });
+
+    it('list_engagements — status フィルタ', async () => {
+      await callOps({ action: 'create_engagement', name: 'Active', status: 'active' });
+      await callOps({ action: 'create_engagement', name: 'Paused', status: 'paused' });
+
+      const activeResult = await callOps({ action: 'list_engagements', status: 'active' });
+      const active = parseResult<Array<{ name: string }>>(activeResult);
+      expect(active).toHaveLength(1);
+      expect(active[0].name).toBe('Active');
+    });
+
+    it('update_engagement — name と status を更新', async () => {
+      const createResult = await callOps({
+        action: 'create_engagement',
+        name: 'Original',
+      });
+      const { id } = parseResult<{ id: string }>(createResult);
+
+      const updateResult = await callOps({
+        action: 'update_engagement',
+        id,
+        name: 'Updated',
+        status: 'paused',
+      });
+      const updated = parseResult<{ name: string; status: string }>(updateResult);
+      expect(updated.name).toBe('Updated');
+      expect(updated.status).toBe('paused');
+    });
+
+    it('update_engagement — 存在しない ID でエラー', async () => {
+      const result = await callOps({
+        action: 'update_engagement',
+        id: '00000000-0000-0000-0000-000000000000',
+        name: 'test',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('not found');
+    });
+
+    it('delete_engagement — 正常削除', async () => {
+      const createResult = await callOps({
+        action: 'create_engagement',
+        name: 'ToDelete',
+      });
+      const { id } = parseResult<{ id: string }>(createResult);
+
+      const deleteResult = await callOps({ action: 'delete_engagement', id });
+      expect(getText(deleteResult)).toContain('deleted successfully');
+
+      // 確認: 取得でエラー
+      const getResult = await callOps({ action: 'get_engagement', id });
+      expect(getResult.isError).toBe(true);
+    });
+
+    it('delete_engagement — 存在しない ID でエラー', async () => {
+      const result = await callOps({
+        action: 'delete_engagement',
+        id: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('get_engagement — id 未指定でエラー', async () => {
+      const result = await callOps({ action: 'get_engagement' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('id parameter is required');
+    });
+  });
+
+  // =========================================================
+  // Run アクション
+  // =========================================================
+
+  describe('Run', () => {
+    let engagementId: string;
+
+    beforeEach(async () => {
+      const result = await callOps({ action: 'create_engagement', name: 'Run Test' });
+      engagementId = parseResult<{ id: string }>(result).id;
+    });
+
+    it('create_run → list_runs → get_run — フルサイクル', async () => {
+      // create
+      const createResult = await callOps({
+        action: 'create_run',
+        engagementId,
+        triggerKind: 'manual',
+        status: 'running',
+      });
+      const run = parseResult<{ id: string; engagementId: string; status: string }>(
+        createResult,
+      );
+      expect(run.engagementId).toBe(engagementId);
+      expect(run.status).toBe('running');
+
+      // list
+      const listResult = await callOps({ action: 'list_runs', engagementId });
+      const runs = parseResult<Array<{ id: string }>>(listResult);
+      expect(runs).toHaveLength(1);
+      expect(runs[0].id).toBe(run.id);
+
+      // get
+      const getResult = await callOps({ action: 'get_run', id: run.id });
+      const fetched = parseResult<{ id: string; triggerKind: string }>(getResult);
+      expect(fetched.id).toBe(run.id);
+      expect(fetched.triggerKind).toBe('manual');
+    });
+
+    it('create_run — 必須パラメータ不足でエラー', async () => {
+      const r1 = await callOps({ action: 'create_run' });
+      expect(r1.isError).toBe(true);
+      expect(getText(r1)).toContain('engagementId');
+
+      const r2 = await callOps({ action: 'create_run', engagementId });
+      expect(r2.isError).toBe(true);
+      expect(getText(r2)).toContain('triggerKind');
+
+      const r3 = await callOps({
+        action: 'create_run',
+        engagementId,
+        triggerKind: 'manual',
+      });
+      expect(r3.isError).toBe(true);
+      expect(getText(r3)).toContain('status');
+    });
+
+    it('update_run_status — succeeded にすると finishedAt が設定される', async () => {
+      const createResult = await callOps({
+        action: 'create_run',
+        engagementId,
+        triggerKind: 'manual',
+        status: 'running',
+      });
+      const { id } = parseResult<{ id: string }>(createResult);
+
+      const updateResult = await callOps({
+        action: 'update_run_status',
+        id,
+        status: 'succeeded',
+        summaryJson: '{"findings":0}',
+      });
+      const updated = parseResult<{
+        status: string;
+        finishedAt: string;
+        summaryJson: string;
+      }>(updateResult);
+      expect(updated.status).toBe('succeeded');
+      expect(updated.finishedAt).toBeDefined();
+      expect(updated.summaryJson).toBe('{"findings":0}');
+    });
+
+    it('update_run_status — 必須パラメータ不足でエラー', async () => {
+      const r1 = await callOps({ action: 'update_run_status' });
+      expect(r1.isError).toBe(true);
+      expect(getText(r1)).toContain('id');
+
+      const r2 = await callOps({
+        action: 'update_run_status',
+        id: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(r2.isError).toBe(true);
+      expect(getText(r2)).toContain('status');
+    });
+
+    it('get_run — 存在しない ID でエラー', async () => {
+      const result = await callOps({
+        action: 'get_run',
+        id: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('not found');
+    });
+
+    it('list_runs — limit パラメータが機能する', async () => {
+      await callOps({
+        action: 'create_run',
+        engagementId,
+        triggerKind: 'manual',
+        status: 'running',
+      });
+      await callOps({
+        action: 'create_run',
+        engagementId,
+        triggerKind: 'schedule',
+        status: 'pending',
+      });
+
+      const result = await callOps({ action: 'list_runs', engagementId, limit: 1 });
+      const runs = parseResult<Array<{ id: string }>>(result);
+      expect(runs).toHaveLength(1);
+    });
+  });
+
+  // =========================================================
+  // ActionQueue アクション
+  // =========================================================
+
+  describe('ActionQueue', () => {
+    let engagementId: string;
+
+    beforeEach(async () => {
+      const result = await callOps({ action: 'create_engagement', name: 'Queue Test' });
+      engagementId = parseResult<{ id: string }>(result).id;
+    });
+
+    it('enqueue_action → poll_action → complete_action — フルライフサイクル', async () => {
+      // enqueue
+      const enqueueResult = await callOps({
+        action: 'enqueue_action',
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:10.0.0.1',
+      });
+      const item = parseResult<{ id: string; state: string; kind: string }>(enqueueResult);
+      expect(item.state).toBe('queued');
+      expect(item.kind).toBe('nmap_scan');
+
+      // poll
+      const pollResult = await callOps({
+        action: 'poll_action',
+        leaseOwner: 'worker-1',
+      });
+      const polled = parseResult<{ id: string; state: string; leaseOwner: string }>(
+        pollResult,
+      );
+      expect(polled.id).toBe(item.id);
+      expect(polled.state).toBe('running');
+      expect(polled.leaseOwner).toBe('worker-1');
+
+      // complete
+      const completeResult = await callOps({
+        action: 'complete_action',
+        id: item.id,
+      });
+      expect(getText(completeResult)).toContain('completed successfully');
+    });
+
+    it('enqueue_action — 必須パラメータ不足でエラー', async () => {
+      const r1 = await callOps({ action: 'enqueue_action' });
+      expect(r1.isError).toBe(true);
+      expect(getText(r1)).toContain('engagementId');
+
+      const r2 = await callOps({ action: 'enqueue_action', engagementId });
+      expect(r2.isError).toBe(true);
+      expect(getText(r2)).toContain('kind');
+
+      const r3 = await callOps({
+        action: 'enqueue_action',
+        engagementId,
+        kind: 'nmap_scan',
+      });
+      expect(r3.isError).toBe(true);
+      expect(getText(r3)).toContain('dedupeKey');
+    });
+
+    it('poll_action — キューが空の場合のメッセージ', async () => {
+      const result = await callOps({
+        action: 'poll_action',
+        leaseOwner: 'worker-1',
+      });
+      expect(getText(result)).toContain('No action available');
+    });
+
+    it('poll_action — leaseOwner 未指定でエラー', async () => {
+      const result = await callOps({ action: 'poll_action' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('leaseOwner');
+    });
+
+    it('fail_action — リトライ可能な場合は queued に戻る', async () => {
+      const enqueueResult = await callOps({
+        action: 'enqueue_action',
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:fail-test',
+        maxAttempts: 3,
+      });
+      const { id } = parseResult<{ id: string }>(enqueueResult);
+
+      // poll
+      await callOps({ action: 'poll_action', leaseOwner: 'worker-1' });
+
+      // fail
+      const failResult = await callOps({
+        action: 'fail_action',
+        id,
+        errorMessage: 'connection timeout',
+      });
+      const afterFail = parseResult<{ state: string; lastError: string }>(failResult);
+      expect(afterFail.state).toBe('queued');
+      expect(afterFail.lastError).toBe('connection timeout');
+    });
+
+    it('fail_action — dead letter (maxAttempts=1)', async () => {
+      const enqueueResult = await callOps({
+        action: 'enqueue_action',
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:dead-letter',
+        maxAttempts: 1,
+      });
+      const { id } = parseResult<{ id: string }>(enqueueResult);
+
+      // poll (attempt_count → 1)
+      await callOps({ action: 'poll_action', leaseOwner: 'worker-1' });
+
+      // fail (attempt_count=1 >= maxAttempts=1 → dead letter)
+      const failResult = await callOps({
+        action: 'fail_action',
+        id,
+        errorMessage: 'permanent failure',
+      });
+      const afterFail = parseResult<{ state: string }>(failResult);
+      expect(afterFail.state).toBe('failed');
+    });
+
+    it('fail_action — 必須パラメータ不足でエラー', async () => {
+      const r1 = await callOps({ action: 'fail_action' });
+      expect(r1.isError).toBe(true);
+      expect(getText(r1)).toContain('id');
+
+      const r2 = await callOps({
+        action: 'fail_action',
+        id: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(r2.isError).toBe(true);
+      expect(getText(r2)).toContain('errorMessage');
+    });
+
+    it('cancel_action — 正常キャンセル', async () => {
+      const enqueueResult = await callOps({
+        action: 'enqueue_action',
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:cancel-test',
+      });
+      const { id } = parseResult<{ id: string }>(enqueueResult);
+
+      const cancelResult = await callOps({ action: 'cancel_action', id });
+      expect(getText(cancelResult)).toContain('cancelled successfully');
+    });
+
+    it('cancel_action — 存在しない ID でエラー', async () => {
+      const result = await callOps({
+        action: 'cancel_action',
+        id: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('list_actions — state フィルタ', async () => {
+      await callOps({
+        action: 'enqueue_action',
+        engagementId,
+        kind: 'nmap_scan',
+        dedupeKey: 'nmap:list-a',
+      });
+      await callOps({
+        action: 'enqueue_action',
+        engagementId,
+        kind: 'nuclei_scan',
+        dedupeKey: 'nuclei:list-b',
+      });
+
+      // 1つ目を poll して running にする
+      await callOps({ action: 'poll_action', leaseOwner: 'worker-1' });
+
+      const queuedResult = await callOps({
+        action: 'list_actions',
+        engagementId,
+        state: 'queued',
+      });
+      const queued = parseResult<Array<{ kind: string }>>(queuedResult);
+      expect(queued).toHaveLength(1);
+      expect(queued[0].kind).toBe('nuclei_scan');
+
+      const runningResult = await callOps({
+        action: 'list_actions',
+        engagementId,
+        state: 'running',
+      });
+      const running = parseResult<Array<{ kind: string }>>(runningResult);
+      expect(running).toHaveLength(1);
+      expect(running[0].kind).toBe('nmap_scan');
+    });
+
+    it('list_actions — engagementId 未指定でエラー', async () => {
+      const result = await callOps({ action: 'list_actions' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('engagementId');
+    });
+  });
+
+  // =========================================================
+  // ActionExecution アクション
+  // =========================================================
+
+  describe('ActionExecution', () => {
+    let engagementId: string;
+    let actionId: string;
+    let runId: string;
+
+    beforeEach(async () => {
+      // engagement を作成
+      const engResult = await callOps({
+        action: 'create_engagement',
+        name: 'Exec Test',
+      });
+      engagementId = parseResult<{ id: string }>(engResult).id;
+
+      // run を作成
+      const runResult = await callOps({
+        action: 'create_run',
+        engagementId,
+        triggerKind: 'manual',
+        status: 'running',
+      });
+      runId = parseResult<{ id: string }>(runResult).id;
+
+      // action を直接 DB に挿入（ops ツール経由で enqueue してもよいが、
+      // execution テストのために action_id が必要なので直接挿入）
+      const crypto = await import('node:crypto');
+      actionId = crypto.randomUUID();
+      const now = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO action_queue (id, engagement_id, run_id, kind, priority, dedupe_key, params_json, state, attempt_count, max_attempts, available_at, created_at, updated_at)
+         VALUES (?, ?, ?, 'nmap_scan', 100, ?, '{}', 'running', 1, 3, ?, ?, ?)`,
+      ).run(actionId, engagementId, runId, `dedupe-${actionId}`, now, now, now);
+
+      // execution を直接 DB に挿入
+      const execId = crypto.randomUUID();
+      db.prepare(
+        `INSERT INTO action_executions (id, action_id, run_id, executor, input_json, output_json, started_at)
+         VALUES (?, ?, ?, 'nmap-executor', '{}', '{}', ?)`,
+      ).run(execId, actionId, runId, now);
+    });
+
+    it('get_execution — 存在する execution を取得できる', async () => {
+      // まず list_executions で ID を取得
+      const listResult = await callOps({
+        action: 'list_executions',
+        actionId,
+      });
+      const executions = parseResult<Array<{ id: string; executor: string }>>(listResult);
+      expect(executions).toHaveLength(1);
+
+      // get_execution
+      const getResult = await callOps({
+        action: 'get_execution',
+        id: executions[0].id,
+      });
+      const exec = parseResult<{ id: string; executor: string; actionId: string }>(
+        getResult,
+      );
+      expect(exec.id).toBe(executions[0].id);
+      expect(exec.executor).toBe('nmap-executor');
+      expect(exec.actionId).toBe(actionId);
+    });
+
+    it('get_execution — 存在しない ID でエラー', async () => {
+      const result = await callOps({
+        action: 'get_execution',
+        id: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('not found');
+    });
+
+    it('get_execution — id 未指定でエラー', async () => {
+      const result = await callOps({ action: 'get_execution' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('id parameter is required');
+    });
+
+    it('list_executions — actionId でフィルタ', async () => {
+      const result = await callOps({
+        action: 'list_executions',
+        actionId,
+      });
+      const executions = parseResult<Array<{ actionId: string }>>(result);
+      expect(executions).toHaveLength(1);
+      expect(executions[0].actionId).toBe(actionId);
+    });
+
+    it('list_executions — runId でフィルタ', async () => {
+      const result = await callOps({
+        action: 'list_executions',
+        runId,
+      });
+      const executions = parseResult<Array<{ runId: string }>>(result);
+      expect(executions).toHaveLength(1);
+      expect(executions[0].runId).toBe(runId);
+    });
+
+    it('list_executions — actionId も runId も未指定でエラー', async () => {
+      const result = await callOps({ action: 'list_executions' });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain('actionId or runId parameter is required');
+    });
+  });
+
+  // =========================================================
+  // ツール登録確認
+  // =========================================================
+
+  it('ops ツールが登録されている', async () => {
+    const result = await client.listTools();
+    const toolNames = result.tools.map((t) => t.name);
+    expect(toolNames).toContain('ops');
+  });
+});

--- a/tests/mcp/tools/ops.test.ts
+++ b/tests/mcp/tools/ops.test.ts
@@ -75,9 +75,7 @@ describe('MCP Ops Tool', () => {
         name: 'Test Engagement',
         environment: 'prod',
       });
-      const created = parseResult<{ id: string; name: string; environment: string }>(
-        createResult,
-      );
+      const created = parseResult<{ id: string; name: string; environment: string }>(createResult);
       expect(created.name).toBe('Test Engagement');
       expect(created.environment).toBe('prod');
       expect(created.id).toBeDefined();
@@ -203,9 +201,7 @@ describe('MCP Ops Tool', () => {
         triggerKind: 'manual',
         status: 'running',
       });
-      const run = parseResult<{ id: string; engagementId: string; status: string }>(
-        createResult,
-      );
+      const run = parseResult<{ id: string; engagementId: string; status: string }>(createResult);
       expect(run.engagementId).toBe(engagementId);
       expect(run.status).toBe('running');
 
@@ -336,9 +332,7 @@ describe('MCP Ops Tool', () => {
         action: 'poll_action',
         leaseOwner: 'worker-1',
       });
-      const polled = parseResult<{ id: string; state: string; leaseOwner: string }>(
-        pollResult,
-      );
+      const polled = parseResult<{ id: string; state: string; leaseOwner: string }>(pollResult);
       expect(polled.id).toBe(item.id);
       expect(polled.state).toBe('running');
       expect(polled.leaseOwner).toBe('worker-1');
@@ -565,9 +559,7 @@ describe('MCP Ops Tool', () => {
         action: 'get_execution',
         id: executions[0].id,
       });
-      const exec = parseResult<{ id: string; executor: string; actionId: string }>(
-        getResult,
-      );
+      const exec = parseResult<{ id: string; executor: string; actionId: string }>(getResult);
       expect(exec.id).toBe(executions[0].id);
       expect(exec.executor).toBe('nmap-executor');
       expect(exec.actionId).toBe(actionId);


### PR DESCRIPTION
## Summary

- 6 Repository classes for v5 operational tables (engagements, runs, action_queue, action_executions, findings, finding_events, risk_snapshots)
- 2 new MCP tools: `ops` (17 actions) and `findings` (9 actions)
- Entity type definitions in `src/types/operational.ts`
- 139 new tests (348 → 487 total)

## New Files

| File | Description |
|------|-------------|
| `src/types/operational.ts` | 7 entity interfaces + input types |
| `src/db/repository/engagement-repository.ts` | Engagement CRUD |
| `src/db/repository/run-repository.ts` | Run CRUD + status transitions |
| `src/db/repository/action-queue-repository.ts` | Action queue with poll/complete/fail |
| `src/db/repository/action-execution-repository.ts` | Execution tracking with duration calc |
| `src/db/repository/finding-repository.ts` | Finding upsert + auto-events |
| `src/db/repository/risk-snapshot-repository.ts` | Risk snapshot history |
| `src/mcp/tools/ops.ts` | ops MCP tool (17 actions) |
| `src/mcp/tools/findings.ts` | findings MCP tool (9 actions) |

## Test plan

- [x] 487 tests pass (`npm test`)
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)