### PR TITLE
Worker向けArtifact Tree実行ライフサイクルを追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ src/
 ├── index.ts             # 現行 stdio MCP entrypoint
 ├── db/
 │   ├── migrate.ts
-│   ├── migrations/      # v0〜v6
+│   ├── migrations/      # v0〜v7
 │   └── repository/
 ├── engine/              # propose、KB index
 ├── mcp/                 # server、tools、resources

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sonobat is an MCP server for sharing missions, actions, attack data, and artifac
 - **Graph Traversal** — SQLite recursive CTE queries for attack path analysis with preset patterns
 - **Knowledge Base** — HackTricks documentation with auto-clone, incremental indexing, and FTS5 full-text search
 - **Continuous Pentest** — Engagement/run lifecycle, action queue with deduplication, finding tracking with state machine, and time-series risk snapshots
-- **MCP Server** — 9 tools + 4 resources accessible via stdio
+- **MCP Server** — 10 tools + 4 resources accessible via stdio
 
 ## Data Model
 
@@ -83,7 +83,7 @@ npm test
 
 sonobat runs as an MCP server over stdio. Tactical controllers and workers use the same server to manage missions and actions, query the graph, and record artifact-backed observations.
 
-### Available Tools (9)
+### Available Tools (10)
 
 | Tool | Actions / Description |
 |------|----------------------|
@@ -103,6 +103,7 @@ sonobat runs as an MCP server over stdio. Tactical controllers and workers use t
 | **`findings`** | Manage findings and risk snapshots |
 | **`missions`** | Create and complete missions, inspect Mission Trees, and retrieve Action Context |
 | **`observe`** | Record an artifact interpretation and apply graph changes atomically |
+| **`worker`** | Start an Action execution, register Artifacts, and finish the Execution and Action atomically |
 
 ### Attack Path Presets
 

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -13,6 +13,7 @@ import v3 from './v3.js';
 import v4 from './v4.js';
 import v5 from './v5.js';
 import v6 from './v6.js';
+import v7 from './v7.js';
 
 export interface Migration {
   version: number;
@@ -21,7 +22,7 @@ export interface Migration {
 }
 
 /** All migrations in order. Must be sorted by version ascending. */
-const migrations: Migration[] = [v0, v1, v2, v3, v4, v5, v6];
+const migrations: Migration[] = [v0, v1, v2, v3, v4, v5, v6, v7];
 
 /** The latest schema version (after all migrations applied). */
 export const LATEST_VERSION: number =

--- a/src/db/migrations/v7.ts
+++ b/src/db/migrations/v7.ts
@@ -1,0 +1,24 @@
+import type Database from 'better-sqlite3';
+import type { Migration } from './index.js';
+
+const migration: Migration = {
+  version: 7,
+  description: 'Add Artifact Tree lineage and metadata columns',
+  up(db: Database.Database): void {
+    db.exec(`
+      ALTER TABLE artifacts ADD COLUMN mission_id TEXT REFERENCES missions(id) ON DELETE SET NULL;
+      ALTER TABLE artifacts ADD COLUMN action_id TEXT REFERENCES action_queue(id) ON DELETE SET NULL;
+      ALTER TABLE artifacts ADD COLUMN media_type TEXT;
+      ALTER TABLE artifacts ADD COLUMN sensitivity TEXT NOT NULL DEFAULT 'internal';
+
+      CREATE INDEX idx_artifacts_mission_captured
+        ON artifacts(mission_id, captured_at DESC);
+      CREATE INDEX idx_artifacts_action_captured
+        ON artifacts(action_id, captured_at DESC);
+      CREATE INDEX idx_artifacts_execution_captured
+        ON artifacts(action_execution_id, captured_at DESC);
+    `);
+  },
+};
+
+export default migration;

--- a/src/db/repository/artifact-repository.ts
+++ b/src/db/repository/artifact-repository.ts
@@ -1,0 +1,99 @@
+import type Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
+import type { Artifact } from '../../types/operational.js';
+
+interface ArtifactRow {
+  id: string;
+  engagement_id: string | null;
+  run_id: string | null;
+  mission_id: string | null;
+  action_id: string | null;
+  action_execution_id: string | null;
+  tool: string;
+  kind: string;
+  path: string;
+  sha256: string | null;
+  media_type: string | null;
+  sensitivity: string;
+  attrs_json: string | null;
+  captured_at: string;
+}
+
+function toArtifact(row: ArtifactRow): Artifact {
+  return {
+    id: row.id,
+    ...(row.engagement_id === null ? {} : { engagementId: row.engagement_id }),
+    ...(row.run_id === null ? {} : { runId: row.run_id }),
+    ...(row.mission_id === null ? {} : { missionId: row.mission_id }),
+    ...(row.action_id === null ? {} : { actionId: row.action_id }),
+    ...(row.action_execution_id === null ? {} : { actionExecutionId: row.action_execution_id }),
+    producer: row.tool,
+    kind: row.kind,
+    path: row.path,
+    ...(row.sha256 === null ? {} : { sha256: row.sha256 }),
+    ...(row.media_type === null ? {} : { mediaType: row.media_type }),
+    sensitivity: row.sensitivity,
+    attrsJson: row.attrs_json ?? '{}',
+    capturedAt: row.captured_at,
+  };
+}
+
+export class ArtifactRepository {
+  constructor(private readonly db: Database.Database) {}
+
+  create(input: {
+    engagementId: string;
+    runId?: string;
+    missionId?: string;
+    actionId: string;
+    actionExecutionId: string;
+    producer: string;
+    kind: string;
+    path: string;
+    sha256?: string;
+    mediaType?: string;
+    sensitivity?: string;
+    attrsJson?: string;
+  }): Artifact {
+    if (input.kind.trim() === '' || input.path.trim() === '') {
+      throw new Error('Artifact kind and path must not be empty');
+    }
+    const attrs: unknown = JSON.parse(input.attrsJson ?? '{}');
+    if (attrs === null || Array.isArray(attrs) || typeof attrs !== 'object') {
+      throw new Error('attrsJson must be a JSON object');
+    }
+    const id = randomUUID();
+    const capturedAt = new Date().toISOString();
+    this.db
+      .prepare(
+        `INSERT INTO artifacts
+         (id, tool, kind, path, sha256, captured_at, attrs_json, engagement_id, run_id,
+          mission_id, action_id, action_execution_id, media_type, sensitivity)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.producer,
+        input.kind,
+        input.path,
+        input.sha256 ?? null,
+        capturedAt,
+        JSON.stringify(attrs),
+        input.engagementId,
+        input.runId ?? null,
+        input.missionId ?? null,
+        input.actionId,
+        input.actionExecutionId,
+        input.mediaType ?? null,
+        input.sensitivity ?? 'internal',
+      );
+    return this.findById(id)!;
+  }
+
+  findById(id: string): Artifact | undefined {
+    const row = this.db.prepare('SELECT * FROM artifacts WHERE id = ?').get(id) as
+      | ArtifactRow
+      | undefined;
+    return row === undefined ? undefined : toArtifact(row);
+  }
+}

--- a/src/db/repository/worker-lifecycle-repository.ts
+++ b/src/db/repository/worker-lifecycle-repository.ts
@@ -1,0 +1,147 @@
+import type Database from 'better-sqlite3';
+import { ActionExecutionRepository } from './action-execution-repository.js';
+import { ActionQueueRepository } from './action-queue-repository.js';
+import { ArtifactRepository } from './artifact-repository.js';
+import type {
+  ActionExecution,
+  ActionQueueItem,
+  Artifact,
+  RegisterArtifactInput,
+} from '../../types/operational.js';
+
+export interface StartExecutionInput {
+  actionId: string;
+  leaseOwner: string;
+  executor: string;
+  command?: string;
+  inputJson?: string;
+}
+
+export interface FinishExecutionInput {
+  executionId: string;
+  leaseOwner: string;
+  outcome: 'succeeded' | 'failed';
+  outputJson?: string;
+  exitCode?: number;
+  errorType?: string;
+  errorMessage?: string;
+  stdoutArtifactId?: string;
+  stderrArtifactId?: string;
+}
+
+export class WorkerLifecycleRepository {
+  private readonly executions: ActionExecutionRepository;
+  private readonly actions: ActionQueueRepository;
+  private readonly artifacts: ArtifactRepository;
+  private readonly finishTx: (input: FinishExecutionInput) => {
+    execution: ActionExecution;
+    action: ActionQueueItem;
+  };
+
+  constructor(private readonly db: Database.Database) {
+    this.executions = new ActionExecutionRepository(db);
+    this.actions = new ActionQueueRepository(db);
+    this.artifacts = new ArtifactRepository(db);
+    this.finishTx = this.db.transaction((input: FinishExecutionInput) => {
+      const execution = this.requireActiveExecution(input.executionId, input.leaseOwner);
+      if (input.outputJson !== undefined) JSON.parse(input.outputJson);
+      this.requireExecutionArtifact(input.stdoutArtifactId, execution.id);
+      this.requireExecutionArtifact(input.stderrArtifactId, execution.id);
+      const completed = this.executions.complete(execution.id, {
+        outputJson: input.outputJson,
+        exitCode: input.exitCode,
+        errorType: input.errorType,
+        errorMessage: input.errorMessage,
+        stdoutArtifactId: input.stdoutArtifactId,
+        stderrArtifactId: input.stderrArtifactId,
+      });
+      if (completed === undefined) throw new Error(`Execution not found: ${execution.id}`);
+
+      const actionUpdated =
+        input.outcome === 'succeeded'
+          ? this.actions.complete(execution.actionId)
+          : this.actions.fail(
+              execution.actionId,
+              input.errorMessage ?? input.errorType ?? 'execution failed',
+            );
+      if (!actionUpdated) throw new Error(`Action could not be finished: ${execution.actionId}`);
+      return { execution: completed, action: this.actions.findById(execution.actionId)! };
+    });
+  }
+
+  startExecution(input: StartExecutionInput): ActionExecution {
+    const action = this.requireLeasedAction(input.actionId, input.leaseOwner);
+    if (input.inputJson !== undefined) JSON.parse(input.inputJson);
+    const active = this.executions
+      .findByAction(action.id)
+      .find((execution) => execution.finishedAt === undefined);
+    if (active !== undefined)
+      throw new Error(`Action already has an active execution: ${active.id}`);
+    return this.executions.create({
+      actionId: action.id,
+      runId: action.runId,
+      executor: input.executor,
+      command: input.command,
+      inputJson: input.inputJson,
+    });
+  }
+
+  registerArtifact(input: RegisterArtifactInput): Artifact {
+    const execution = this.requireActiveExecution(input.executionId, input.leaseOwner);
+    const action = this.actions.findById(execution.actionId)!;
+    return this.artifacts.create({
+      engagementId: action.engagementId,
+      runId: action.runId,
+      missionId: action.missionId,
+      actionId: action.id,
+      actionExecutionId: execution.id,
+      producer: input.leaseOwner,
+      kind: input.kind,
+      path: input.path,
+      sha256: input.sha256,
+      mediaType: input.mediaType,
+      sensitivity: input.sensitivity,
+      attrsJson: input.attrsJson,
+    });
+  }
+
+  finishExecution(input: FinishExecutionInput): {
+    execution: ActionExecution;
+    action: ActionQueueItem;
+  } {
+    return this.finishTx(input);
+  }
+
+  private requireActiveExecution(executionId: string, leaseOwner: string): ActionExecution {
+    const execution = this.executions.findById(executionId);
+    if (execution === undefined) throw new Error(`Execution not found: ${executionId}`);
+    if (execution.finishedAt !== undefined)
+      throw new Error(`Execution already finished: ${executionId}`);
+    this.requireLeasedAction(execution.actionId, leaseOwner);
+    return execution;
+  }
+
+  private requireLeasedAction(actionId: string, leaseOwner: string): ActionQueueItem {
+    const action = this.actions.findById(actionId);
+    if (action === undefined) throw new Error(`Action not found: ${actionId}`);
+    if (action.state !== 'running') throw new Error(`Action is not running: ${actionId}`);
+    if (action.leaseOwner !== leaseOwner) throw new Error(`Action lease owner does not match`);
+    if (
+      action.leaseExpiresAt === undefined ||
+      new Date(action.leaseExpiresAt).getTime() <= Date.now()
+    ) {
+      throw new Error(`Action lease has expired`);
+    }
+    return action;
+  }
+
+  private requireExecutionArtifact(artifactId: string | undefined, executionId: string): void {
+    if (artifactId === undefined) return;
+    const row = this.db
+      .prepare('SELECT action_execution_id FROM artifacts WHERE id = ?')
+      .get(artifactId) as { action_execution_id: string | null } | undefined;
+    if (row?.action_execution_id !== executionId) {
+      throw new Error(`Artifact does not belong to execution: ${artifactId}`);
+    }
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -15,6 +15,7 @@ import { registerFindingsTools } from './tools/findings.js';
 import { registerResources } from './resources.js';
 import { registerMissionTool } from './tools/missions.js';
 import { registerObservationTool } from './tools/observations.js';
+import { registerWorkerTool } from './tools/worker.js';
 
 /**
  * Create a fully configured MCP server with all sonobat tools and resources.
@@ -38,6 +39,7 @@ export function createMcpServer(db: Database.Database, version?: string): McpSer
   registerFindingsTools(server, db); // findings (finding/risk management)
   registerMissionTool(server, db);
   registerObservationTool(server, db);
+  registerWorkerTool(server, db);
 
   // Register resources
   registerResources(server, db);

--- a/src/mcp/tools/worker.ts
+++ b/src/mcp/tools/worker.ts
@@ -1,0 +1,86 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type Database from 'better-sqlite3';
+import { z } from 'zod';
+import { WorkerLifecycleRepository } from '../../db/repository/worker-lifecycle-repository.js';
+
+export function registerWorkerTool(server: McpServer, db: Database.Database): void {
+  const lifecycle = new WorkerLifecycleRepository(db);
+  server.tool(
+    'worker',
+    'Record Worker execution and artifacts for a leased Action',
+    {
+      action: z.enum(['start_execution', 'register_artifact', 'finish_execution']),
+      actionId: z.string().optional(),
+      executionId: z.string().optional(),
+      leaseOwner: z.string(),
+      executor: z.string().optional(),
+      command: z.string().optional(),
+      inputJson: z.string().optional(),
+      outputJson: z.string().optional(),
+      outcome: z.enum(['succeeded', 'failed']).optional(),
+      exitCode: z.number().int().optional(),
+      errorType: z.string().optional(),
+      errorMessage: z.string().optional(),
+      stdoutArtifactId: z.string().optional(),
+      stderrArtifactId: z.string().optional(),
+      kind: z.string().optional(),
+      path: z.string().optional(),
+      sha256: z.string().optional(),
+      mediaType: z.string().optional(),
+      sensitivity: z.string().optional(),
+      attrsJson: z.string().optional(),
+    },
+    async (input) => {
+      try {
+        if (input.action === 'start_execution') {
+          if (!input.actionId || !input.executor) {
+            throw new Error('actionId and executor are required for start_execution');
+          }
+          const execution = lifecycle.startExecution({
+            actionId: input.actionId,
+            leaseOwner: input.leaseOwner,
+            executor: input.executor,
+            command: input.command,
+            inputJson: input.inputJson,
+          });
+          return { content: [{ type: 'text', text: JSON.stringify(execution, null, 2) }] };
+        }
+        if (!input.executionId) throw new Error('executionId is required');
+        if (input.action === 'register_artifact') {
+          if (!input.kind || !input.path) {
+            throw new Error('kind and path are required for register_artifact');
+          }
+          const artifact = lifecycle.registerArtifact({
+            executionId: input.executionId,
+            leaseOwner: input.leaseOwner,
+            kind: input.kind,
+            path: input.path,
+            sha256: input.sha256,
+            mediaType: input.mediaType,
+            sensitivity: input.sensitivity,
+            attrsJson: input.attrsJson,
+          });
+          return { content: [{ type: 'text', text: JSON.stringify(artifact, null, 2) }] };
+        }
+        if (!input.outcome) throw new Error('outcome is required for finish_execution');
+        const result = lifecycle.finishExecution({
+          executionId: input.executionId,
+          leaseOwner: input.leaseOwner,
+          outcome: input.outcome,
+          outputJson: input.outputJson,
+          exitCode: input.exitCode,
+          errorType: input.errorType,
+          errorMessage: input.errorMessage,
+          stdoutArtifactId: input.stdoutArtifactId,
+          stderrArtifactId: input.stderrArtifactId,
+        });
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (error) {
+        return {
+          content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/types/operational.ts
+++ b/src/types/operational.ts
@@ -92,6 +92,34 @@ export interface ObservationRecord {
   createdAt: string;
 }
 
+export interface Artifact {
+  id: string;
+  engagementId?: string;
+  runId?: string;
+  missionId?: string;
+  actionId?: string;
+  actionExecutionId?: string;
+  producer: string;
+  kind: string;
+  path: string;
+  sha256?: string;
+  mediaType?: string;
+  sensitivity: string;
+  attrsJson: string;
+  capturedAt: string;
+}
+
+export type RegisterArtifactInput = {
+  executionId: string;
+  leaseOwner: string;
+  kind: string;
+  path: string;
+  sha256?: string;
+  mediaType?: string;
+  sensitivity?: string;
+  attrsJson?: string;
+};
+
 // ============================================================
 // ActionQueueItem
 // ============================================================

--- a/tests/db/migrations/v7.test.ts
+++ b/tests/db/migrations/v7.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+
+describe('Migration v7', () => {
+  it('Artifact Treeの由来とメタデータ列を追加する', () => {
+    const db = new Database(':memory:');
+    migrateDatabase(db);
+    const columns = db.prepare("PRAGMA table_info('artifacts')").all() as Array<{ name: string }>;
+    const names = columns.map((column) => column.name);
+    expect(names).toContain('mission_id');
+    expect(names).toContain('action_id');
+    expect(names).toContain('action_execution_id');
+    expect(names).toContain('media_type');
+    expect(names).toContain('sensitivity');
+  });
+});

--- a/tests/db/repository/worker-lifecycle-repository.test.ts
+++ b/tests/db/repository/worker-lifecycle-repository.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+import { MissionRepository } from '../../../src/db/repository/mission-repository.js';
+import { ActionQueueRepository } from '../../../src/db/repository/action-queue-repository.js';
+import { WorkerLifecycleRepository } from '../../../src/db/repository/worker-lifecycle-repository.js';
+
+describe('WorkerLifecycleRepository', () => {
+  let db: InstanceType<typeof Database>;
+  let actions: ActionQueueRepository;
+  let lifecycle: WorkerLifecycleRepository;
+  let actionId: string;
+  let missionId: string;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migrateDatabase(db);
+    const engagement = new EngagementRepository(db).create({ name: 'test' });
+    const mission = new MissionRepository(db).create({
+      engagementId: engagement.id,
+      objective: 'Webの攻撃面を調査する',
+    });
+    missionId = mission.id;
+    actions = new ActionQueueRepository(db);
+    const action = actions.enqueue({
+      engagementId: engagement.id,
+      missionId,
+      kind: 'web_endpoint_discovery',
+      dedupeKey: 'web:test',
+    });
+    actionId = action.id;
+    actions.poll('worker-1');
+    lifecycle = new WorkerLifecycleRepository(db);
+  });
+
+  it('lease所有者がExecutionを開始してArtifactを登録できる', () => {
+    const execution = lifecycle.startExecution({
+      actionId,
+      leaseOwner: 'worker-1',
+      executor: 'worker-1',
+      inputJson: '{"target":"example.test"}',
+    });
+    const artifact = lifecycle.registerArtifact({
+      executionId: execution.id,
+      leaseOwner: 'worker-1',
+      kind: 'stdout',
+      path: 'artifact://stdout',
+      sha256: 'abc123',
+      mediaType: 'text/plain',
+    });
+
+    expect(artifact.actionId).toBe(actionId);
+    expect(artifact.missionId).toBe(missionId);
+    expect(artifact.actionExecutionId).toBe(execution.id);
+  });
+
+  it('別WorkerのleaseではExecutionを開始できない', () => {
+    expect(() =>
+      lifecycle.startExecution({
+        actionId,
+        leaseOwner: 'worker-2',
+        executor: 'worker-2',
+      }),
+    ).toThrow(/lease owner/);
+  });
+
+  it('期限切れleaseではExecutionを開始できない', () => {
+    db.prepare('UPDATE action_queue SET lease_expires_at = ? WHERE id = ?').run(
+      '2000-01-01T00:00:00.000Z',
+      actionId,
+    );
+    expect(() =>
+      lifecycle.startExecution({
+        actionId,
+        leaseOwner: 'worker-1',
+        executor: 'worker-1',
+      }),
+    ).toThrow(/expired/);
+  });
+
+  it('成功時はExecutionとActionを一つの操作で完了する', () => {
+    const execution = lifecycle.startExecution({
+      actionId,
+      leaseOwner: 'worker-1',
+      executor: 'worker-1',
+    });
+
+    const result = lifecycle.finishExecution({
+      executionId: execution.id,
+      leaseOwner: 'worker-1',
+      outcome: 'succeeded',
+      outputJson: '{"count":3}',
+      exitCode: 0,
+    });
+
+    expect(result.execution.finishedAt).toBeDefined();
+    expect(result.action.state).toBe('succeeded');
+    expect(() =>
+      lifecycle.finishExecution({
+        executionId: execution.id,
+        leaseOwner: 'worker-1',
+        outcome: 'succeeded',
+      }),
+    ).toThrow(/already finished/);
+  });
+
+  it('失敗時はExecutionへエラーを保存してActionを再試行可能にする', () => {
+    const execution = lifecycle.startExecution({
+      actionId,
+      leaseOwner: 'worker-1',
+      executor: 'worker-1',
+    });
+
+    const result = lifecycle.finishExecution({
+      executionId: execution.id,
+      leaseOwner: 'worker-1',
+      outcome: 'failed',
+      errorType: 'timeout',
+      errorMessage: 'request timed out',
+    });
+
+    expect(result.execution.errorType).toBe('timeout');
+    expect(result.action.state).toBe('queued');
+    expect(result.action.lastError).toBe('request timed out');
+  });
+});

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -44,7 +44,7 @@ describe('MCP Server', () => {
   // ツール登録確認
   // =========================================================
 
-  it('9 ツールが登録されている', async () => {
+  it('10 ツールが登録されている', async () => {
     const result = await client.listTools();
     const toolNames = result.tools.map((t) => t.name).sort();
 
@@ -57,7 +57,8 @@ describe('MCP Server', () => {
     expect(toolNames).toContain('findings');
     expect(toolNames).toContain('missions');
     expect(toolNames).toContain('observe');
-    expect(result.tools.length).toBe(9);
+    expect(toolNames).toContain('worker');
+    expect(result.tools.length).toBe(10);
   });
 
   it('リソースが登録されている', async () => {

--- a/tests/mcp/tools/worker.test.ts
+++ b/tests/mcp/tools/worker.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { createMcpServer } from '../../../src/mcp/server.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+import { MissionRepository } from '../../../src/db/repository/mission-repository.js';
+import { ActionQueueRepository } from '../../../src/db/repository/action-queue-repository.js';
+
+describe('worker MCP tool', () => {
+  let db: InstanceType<typeof Database>;
+  let client: Client;
+  let actionId: string;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    migrateDatabase(db);
+    const engagement = new EngagementRepository(db).create({ name: 'test' });
+    const mission = new MissionRepository(db).create({
+      engagementId: engagement.id,
+      objective: '対象を調査する',
+    });
+    const actions = new ActionQueueRepository(db);
+    actionId = actions.enqueue({
+      engagementId: engagement.id,
+      missionId: mission.id,
+      kind: 'network_service_discovery',
+      dedupeKey: 'test-action',
+    }).id;
+    actions.poll('worker-1');
+
+    const server = createMcpServer(db);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new Client({ name: 'test-client', version: '1.0.0' });
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  it('Execution、Artifact、Action完了を記録する', async () => {
+    const started = await client.callTool({
+      name: 'worker',
+      arguments: {
+        action: 'start_execution',
+        actionId,
+        leaseOwner: 'worker-1',
+        executor: 'worker-1',
+      },
+    });
+    const execution = JSON.parse(
+      (started.content as Array<{ type: string; text: string }>)[0].text,
+    ) as { id: string };
+
+    const registered = await client.callTool({
+      name: 'worker',
+      arguments: {
+        action: 'register_artifact',
+        executionId: execution.id,
+        leaseOwner: 'worker-1',
+        kind: 'stdout',
+        path: 'artifact://stdout',
+      },
+    });
+    expect(registered.isError).not.toBe(true);
+
+    const finished = await client.callTool({
+      name: 'worker',
+      arguments: {
+        action: 'finish_execution',
+        executionId: execution.id,
+        leaseOwner: 'worker-1',
+        outcome: 'succeeded',
+        exitCode: 0,
+      },
+    });
+    const result = JSON.parse(
+      (finished.content as Array<{ type: string; text: string }>)[0].text,
+    ) as { action: { state: string } };
+    expect(result.action.state).toBe('succeeded');
+  });
+});


### PR DESCRIPTION
## 変更内容

- ArtifactへMission、Action、Execution、Media Type、機密区分を追加するv7 Migration
- 汎用的なArtifact Repository
- Worker向け `worker` MCP tool
- leaseを検証したExecution開始
- 標準出力、標準エラー、生成ファイルのArtifact登録
- ExecutionとActionの原子的な終了
- 失敗Actionの既存再試行規則への復帰
- 二重終了、別Worker、期限切れlease、不正JSONの検証
- README、AGENTS.md、Wikiの更新

## 変更理由

専用Parserと `ingest_file` の削除後も、Workerが任意の実行結果をArtifact Treeへ記録できる経路が必要なためです。

Sonobatはコマンドを実行せず、外部Workerが実行した結果と由来だけを管理します。

## 検証

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test`（415 tests）
- `npm run build`

Closes #36
