### PR TITLE
Worker capabilityに基づくAction取得とlease更新を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ sonobat runs as an MCP server over stdio. Tactical controllers and workers use t
 | **`observe`** | Record an artifact interpretation and apply graph changes atomically |
 | **`worker`** | Start an Action execution, register Artifacts, and finish the Execution and Action atomically |
 
+`poll_action` requires the Action kinds supported by the Worker. The `worker` tool can renew an active lease while a long-running Action is in progress.
+
 ### Attack Path Presets
 
 | Pattern | Description |

--- a/src/db/repository/action-queue-repository.ts
+++ b/src/db/repository/action-queue-repository.ts
@@ -80,7 +80,6 @@ export class ActionQueueRepository {
 
   private readonly insertStmt: Database.Statement;
   private readonly selectByIdStmt: Database.Statement;
-  private readonly pollStmt: Database.Statement;
   private readonly completeStmt: Database.Statement;
   private readonly requeueStmt: Database.Statement;
   private readonly deadLetterStmt: Database.Statement;
@@ -108,22 +107,6 @@ export class ActionQueueRepository {
               available_at, lease_owner, lease_expires_at, last_error,
               created_at, updated_at
        FROM action_queue WHERE id = ?`,
-    );
-
-    this.pollStmt = this.db.prepare(
-      `UPDATE action_queue
-       SET state = 'running',
-           lease_owner = ?,
-           lease_expires_at = ?,
-           attempt_count = attempt_count + 1,
-           updated_at = ?
-       WHERE id = (
-         SELECT id FROM action_queue
-         WHERE state = 'queued' AND available_at <= ?
-         ORDER BY priority ASC, created_at ASC
-         LIMIT 1
-       )
-       RETURNING *`,
     );
 
     this.completeStmt = this.db.prepare(
@@ -296,13 +279,33 @@ export class ActionQueueRepository {
    * @param leaseDurationSec リース期間（秒）。デフォルト 300秒。
    * @returns ポーリングしたアクション。キューが空なら undefined。
    */
-  poll(leaseOwner: string, leaseDurationSec?: number): ActionQueueItem | undefined {
+  poll(
+    leaseOwner: string,
+    leaseDurationSec?: number,
+    acceptedKinds?: string[],
+  ): ActionQueueItem | undefined {
+    if (acceptedKinds !== undefined && acceptedKinds.length === 0) {
+      throw new Error('acceptedKinds must not be empty');
+    }
     const duration = leaseDurationSec ?? 300;
     const now = new Date();
     const nowIso = now.toISOString();
     const leaseExpiresAt = new Date(now.getTime() + duration * 1000).toISOString();
 
-    const row = this.pollStmt.get(leaseOwner, leaseExpiresAt, nowIso, nowIso) as
+    const kindFilter =
+      acceptedKinds === undefined ? '' : `AND kind IN (${acceptedKinds.map(() => '?').join(', ')})`;
+    const row = this.db
+      .prepare(
+        `UPDATE action_queue
+         SET state = 'running', lease_owner = ?, lease_expires_at = ?,
+             attempt_count = attempt_count + 1, updated_at = ?
+         WHERE id = (
+           SELECT id FROM action_queue
+           WHERE state = 'queued' AND available_at <= ? ${kindFilter}
+           ORDER BY priority ASC, created_at ASC LIMIT 1
+         ) RETURNING *`,
+      )
+      .get(leaseOwner, leaseExpiresAt, nowIso, nowIso, ...(acceptedKinds ?? [])) as
       | ActionQueueRow
       | undefined;
 
@@ -310,6 +313,39 @@ export class ActionQueueRepository {
       return undefined;
     }
     return rowToActionQueueItem(row);
+  }
+
+  renewLease(
+    id: string,
+    leaseOwner: string,
+    leaseDurationSec: number = 300,
+  ): ActionQueueItem | undefined {
+    const now = new Date();
+    const result = this.db
+      .prepare(
+        `UPDATE action_queue SET lease_expires_at = ?, updated_at = ?
+         WHERE id = ? AND state = 'running' AND lease_owner = ? AND lease_expires_at > ?
+         RETURNING *`,
+      )
+      .get(
+        new Date(now.getTime() + leaseDurationSec * 1000).toISOString(),
+        now.toISOString(),
+        id,
+        leaseOwner,
+        now.toISOString(),
+      ) as ActionQueueRow | undefined;
+    return result === undefined ? undefined : rowToActionQueueItem(result);
+  }
+
+  reclaimExpired(): number {
+    const now = new Date().toISOString();
+    return this.db
+      .prepare(
+        `UPDATE action_queue SET state = 'queued', lease_owner = NULL, lease_expires_at = NULL,
+         available_at = ?, updated_at = ?
+         WHERE state = 'running' AND lease_expires_at <= ?`,
+      )
+      .run(now, now, now).changes;
   }
 
   /**

--- a/src/mcp/tools/ops.ts
+++ b/src/mcp/tools/ops.ts
@@ -61,6 +61,7 @@ export function registerOpsTools(server: McpServer, db: Database.Database): void
       kind: z.string().optional().describe('Action kind'),
       dedupeKey: z.string().optional().describe('Action deduplication key'),
       leaseOwner: z.string().optional().describe('Lease owner for poll'),
+      acceptedKinds: z.array(z.string()).optional().describe('Action kinds accepted by Worker'),
       errorMessage: z.string().optional().describe('Error message for fail'),
       scopeJson: z.string().optional().describe('Scope as JSON'),
       policyJson: z.string().optional().describe('Policy as JSON'),
@@ -90,6 +91,7 @@ export function registerOpsTools(server: McpServer, db: Database.Database): void
       kind,
       dedupeKey,
       leaseOwner,
+      acceptedKinds,
       errorMessage,
       scopeJson,
       policyJson,
@@ -341,7 +343,14 @@ export function registerOpsTools(server: McpServer, db: Database.Database): void
                 isError: true,
               };
             }
-            const polled = actionQueueRepo.poll(leaseOwner, leaseDurationSec);
+            if (!acceptedKinds || acceptedKinds.length === 0) {
+              return {
+                content: [{ type: 'text', text: 'acceptedKinds is required for poll_action' }],
+                isError: true,
+              };
+            }
+            actionQueueRepo.reclaimExpired();
+            const polled = actionQueueRepo.poll(leaseOwner, leaseDurationSec, acceptedKinds);
             if (!polled) {
               return {
                 content: [{ type: 'text', text: 'No action available to poll' }],

--- a/src/mcp/tools/worker.ts
+++ b/src/mcp/tools/worker.ts
@@ -2,14 +2,16 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type Database from 'better-sqlite3';
 import { z } from 'zod';
 import { WorkerLifecycleRepository } from '../../db/repository/worker-lifecycle-repository.js';
+import { ActionQueueRepository } from '../../db/repository/action-queue-repository.js';
 
 export function registerWorkerTool(server: McpServer, db: Database.Database): void {
   const lifecycle = new WorkerLifecycleRepository(db);
+  const actions = new ActionQueueRepository(db);
   server.tool(
     'worker',
     'Record Worker execution and artifacts for a leased Action',
     {
-      action: z.enum(['start_execution', 'register_artifact', 'finish_execution']),
+      action: z.enum(['start_execution', 'register_artifact', 'finish_execution', 'renew_lease']),
       actionId: z.string().optional(),
       executionId: z.string().optional(),
       leaseOwner: z.string(),
@@ -32,6 +34,12 @@ export function registerWorkerTool(server: McpServer, db: Database.Database): vo
     },
     async (input) => {
       try {
+        if (input.action === 'renew_lease') {
+          if (!input.actionId) throw new Error('actionId is required for renew_lease');
+          const renewed = actions.renewLease(input.actionId, input.leaseOwner);
+          if (!renewed) throw new Error('Action lease could not be renewed');
+          return { content: [{ type: 'text', text: JSON.stringify(renewed, null, 2) }] };
+        }
         if (input.action === 'start_execution') {
           if (!input.actionId || !input.executor) {
             throw new Error('actionId and executor are required for start_execution');

--- a/tests/db/repository/action-queue-repository.test.ts
+++ b/tests/db/repository/action-queue-repository.test.ts
@@ -148,6 +148,18 @@ describe('ActionQueueRepository', () => {
   // =======================================================================
 
   describe('poll()', () => {
+    it('acceptedKindsに含まれるActionだけを取得する', () => {
+      repo.enqueue({ engagementId, kind: 'web', dedupeKey: 'web:1' });
+      const network = repo.enqueue({ engagementId, kind: 'network', dedupeKey: 'network:1' });
+
+      const polled = repo.poll('worker-1', 300, ['network']);
+
+      expect(polled?.id).toBe(network.id);
+    });
+
+    it('空のacceptedKindsを拒否する', () => {
+      expect(() => repo.poll('worker-1', 300, [])).toThrow(/must not be empty/);
+    });
     it('基本ポーリング — returns oldest queued item, sets state=running with lease', () => {
       const created = repo.enqueue({
         engagementId,
@@ -210,6 +222,28 @@ describe('ActionQueueRepository', () => {
       expect(polled).toBeDefined();
       expect(polled!.id).toBe(lowPriority.id);
       expect(polled!.kind).toBe('critical_scan');
+    });
+  });
+
+  describe('lease lifecycle', () => {
+    it('所有者が有効なleaseを更新できる', () => {
+      const action = repo.enqueue({ engagementId, kind: 'network', dedupeKey: 'renew:1' });
+      repo.poll('worker-1', 60, ['network']);
+
+      expect(repo.renewLease(action.id, 'worker-1', 300)?.leaseOwner).toBe('worker-1');
+      expect(repo.renewLease(action.id, 'worker-2', 300)).toBeUndefined();
+    });
+
+    it('期限切れActionをQueueへ戻して再取得できる', () => {
+      const action = repo.enqueue({ engagementId, kind: 'network', dedupeKey: 'expired:1' });
+      repo.poll('worker-1', 60, ['network']);
+      db.prepare('UPDATE action_queue SET lease_expires_at = ? WHERE id = ?').run(
+        '2000-01-01T00:00:00.000Z',
+        action.id,
+      );
+
+      expect(repo.reclaimExpired()).toBe(1);
+      expect(repo.poll('worker-2', 60, ['network'])?.id).toBe(action.id);
     });
   });
 

--- a/tests/mcp/tools/ops.test.ts
+++ b/tests/mcp/tools/ops.test.ts
@@ -331,6 +331,7 @@ describe('MCP Ops Tool', () => {
       const pollResult = await callOps({
         action: 'poll_action',
         leaseOwner: 'worker-1',
+        acceptedKinds: ['nmap_scan', 'nuclei_scan'],
       });
       const polled = parseResult<{ id: string; state: string; leaseOwner: string }>(pollResult);
       expect(polled.id).toBe(item.id);
@@ -367,6 +368,7 @@ describe('MCP Ops Tool', () => {
       const result = await callOps({
         action: 'poll_action',
         leaseOwner: 'worker-1',
+        acceptedKinds: ['nmap_scan', 'nuclei_scan'],
       });
       expect(getText(result)).toContain('No action available');
     });
@@ -388,7 +390,11 @@ describe('MCP Ops Tool', () => {
       const { id } = parseResult<{ id: string }>(enqueueResult);
 
       // poll
-      await callOps({ action: 'poll_action', leaseOwner: 'worker-1' });
+      await callOps({
+        action: 'poll_action',
+        leaseOwner: 'worker-1',
+        acceptedKinds: ['nmap_scan', 'nuclei_scan'],
+      });
 
       // fail
       const failResult = await callOps({
@@ -412,7 +418,11 @@ describe('MCP Ops Tool', () => {
       const { id } = parseResult<{ id: string }>(enqueueResult);
 
       // poll (attempt_count → 1)
-      await callOps({ action: 'poll_action', leaseOwner: 'worker-1' });
+      await callOps({
+        action: 'poll_action',
+        leaseOwner: 'worker-1',
+        acceptedKinds: ['nmap_scan', 'nuclei_scan'],
+      });
 
       // fail (attempt_count=1 >= maxAttempts=1 → dead letter)
       const failResult = await callOps({
@@ -473,7 +483,11 @@ describe('MCP Ops Tool', () => {
       });
 
       // 1つ目を poll して running にする
-      await callOps({ action: 'poll_action', leaseOwner: 'worker-1' });
+      await callOps({
+        action: 'poll_action',
+        leaseOwner: 'worker-1',
+        acceptedKinds: ['nmap_scan', 'nuclei_scan'],
+      });
 
       const queuedResult = await callOps({
         action: 'list_actions',


### PR DESCRIPTION
## 変更内容

- `poll_action` でWorkerが対応可能なAction種類を必須化
- Action種類による原子的なQueue取得
- 有効なleaseを所有者だけが更新する `renew_lease`
- 期限切れActionをQueueへ戻して再取得
- 競合、空のAction種類、不正所有者、期限切れのテスト
- READMEとWikiを更新

## 検証

- format
- lint
- typecheck
- 419 tests
- build

Closes #38