### PR TITLE
HTTP Originを含む拡張可能なGraphモデルへ移行する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ src/
 ├── index.ts             # 現行 stdio MCP entrypoint
 ├── db/
 │   ├── migrate.ts
-│   ├── migrations/      # v0〜v7
+│   ├── migrations/      # v0〜v8
 │   └── repository/
 ├── engine/              # propose、KB index
 ├── mcp/                 # server、tools、resources

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ sonobat is an MCP server for sharing missions, actions, attack data, and artifac
 - **Mission Tree** — Organize tactical objectives, actions, and derived child actions
 - **Artifact Tree** — Trace observations and graph changes back to executions and artifacts
 - **Observation** — Apply an artifact interpretation and graph changes in one transaction
-- **Graph-Native Schema** — Generic `nodes` + `edges` tables with Zod-validated props for 10 node kinds and 13 edge kinds
+- **Graph-Native Schema** — Generic `nodes` + `edges` tables with Zod-validated, Migration-defined kinds
 - **Propose** — Gap-driven engine suggests what to scan next based on missing data
 - **Graph Traversal** — SQLite recursive CTE queries for attack path analysis with preset patterns
 - **Knowledge Base** — HackTricks documentation with auto-clone, incremental indexing, and FTS5 full-text search
@@ -32,6 +32,9 @@ nodes (kind + props_json)
  ├── vulnerability — Detected vulnerability
  ├── cve          — CVE record
  └── svc_observation — Service-level key-value observation
+ ├── network_endpoint — Transport + port exposed by a host
+ ├── http_origin    — Scheme + hostname + port served by a network endpoint
+ └── web_endpoint   — HTTP method + path within an origin
 
 edges (kind + source_id + target_id)
  HOST_SERVICE, HOST_VHOST, SERVICE_ENDPOINT, SERVICE_INPUT,

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -14,6 +14,7 @@ import v4 from './v4.js';
 import v5 from './v5.js';
 import v6 from './v6.js';
 import v7 from './v7.js';
+import v8 from './v8.js';
 
 export interface Migration {
   version: number;
@@ -22,7 +23,7 @@ export interface Migration {
 }
 
 /** All migrations in order. Must be sorted by version ascending. */
-const migrations: Migration[] = [v0, v1, v2, v3, v4, v5, v6, v7];
+const migrations: Migration[] = [v0, v1, v2, v3, v4, v5, v6, v7, v8];
 
 /** The latest schema version (after all migrations applied). */
 export const LATEST_VERSION: number =

--- a/src/db/migrations/v8.ts
+++ b/src/db/migrations/v8.ts
@@ -1,0 +1,137 @@
+import type Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
+import type { Migration } from './index.js';
+
+interface LegacyService {
+  id: string;
+  props_json: string;
+  evidence_artifact_id: string | null;
+  created_at: string;
+  updated_at: string;
+  host_id: string;
+}
+
+interface LegacyEndpoint {
+  id: string;
+  props_json: string;
+  evidence_artifact_id: string | null;
+  created_at: string;
+  updated_at: string;
+  service_id: string;
+}
+
+const migration: Migration = {
+  version: 8,
+  description: 'Add Network Endpoint, HTTP Origin, and Web Endpoint graph model',
+  up(db: Database.Database): void {
+    db.exec(`
+      INSERT INTO graph_node_kinds (kind, description) VALUES
+        ('network_endpoint', 'Transport endpoint exposed by a host'),
+        ('http_origin', 'HTTP origin served by a network endpoint'),
+        ('web_endpoint', 'HTTP method and path within an origin');
+      INSERT INTO graph_edge_kinds (kind, description) VALUES
+        ('HOST_NETWORK_ENDPOINT', 'Host exposes network endpoint'),
+        ('NETWORK_ENDPOINT_HTTP_ORIGIN', 'Network endpoint serves HTTP origin'),
+        ('HTTP_ORIGIN_WEB_ENDPOINT', 'HTTP origin exposes Web endpoint');
+    `);
+
+    const services = db
+      .prepare(
+        `SELECT n.*, e.source_id host_id FROM nodes n
+         JOIN edges e ON e.target_id = n.id AND e.kind = 'HOST_SERVICE'
+         WHERE n.kind = 'service'`,
+      )
+      .all() as LegacyService[];
+    const serviceMap = new Map<string, string>();
+    for (const service of services) {
+      const props = JSON.parse(service.props_json) as Record<string, unknown>;
+      const id = randomUUID();
+      serviceMap.set(service.id, id);
+      db.prepare(`INSERT INTO nodes VALUES (?, 'network_endpoint', ?, ?, ?, ?, ?)`).run(
+        id,
+        `net:${service.host_id}:${props.transport}:${props.port}`,
+        JSON.stringify({
+          transport: props.transport,
+          port: props.port,
+          state: props.state,
+          protocolHint: props.appProto,
+          banner: props.banner,
+          product: props.product,
+          version: props.version,
+        }),
+        service.evidence_artifact_id,
+        service.created_at,
+        service.updated_at,
+      );
+      db.prepare(`INSERT INTO edges VALUES (?, 'HOST_NETWORK_ENDPOINT', ?, ?, '{}', ?, ?)`).run(
+        randomUUID(),
+        service.host_id,
+        id,
+        service.evidence_artifact_id,
+        service.created_at,
+      );
+    }
+
+    const endpoints = db
+      .prepare(
+        `SELECT n.*, e.source_id service_id FROM nodes n
+         JOIN edges e ON e.target_id = n.id AND e.kind = 'SERVICE_ENDPOINT'
+         WHERE n.kind = 'endpoint'`,
+      )
+      .all() as LegacyEndpoint[];
+    for (const endpoint of endpoints) {
+      const networkId = serviceMap.get(endpoint.service_id);
+      if (networkId === undefined) continue;
+      const props = JSON.parse(endpoint.props_json) as Record<string, unknown>;
+      const url = new URL(String(props.baseUri));
+      const port = url.port === '' ? (url.protocol === 'https:' ? 443 : 80) : Number(url.port);
+      const originKey = `origin:${networkId}:${url.protocol.slice(0, -1)}:${url.hostname}:${port}`;
+      let origin = db.prepare('SELECT id FROM nodes WHERE natural_key = ?').get(originKey) as
+        | { id: string }
+        | undefined;
+      if (origin === undefined) {
+        origin = { id: randomUUID() };
+        db.prepare(`INSERT INTO nodes VALUES (?, 'http_origin', ?, ?, ?, ?, ?)`).run(
+          origin.id,
+          originKey,
+          JSON.stringify({ scheme: url.protocol.slice(0, -1), hostname: url.hostname, port }),
+          endpoint.evidence_artifact_id,
+          endpoint.created_at,
+          endpoint.updated_at,
+        );
+        db.prepare(
+          `INSERT INTO edges VALUES (?, 'NETWORK_ENDPOINT_HTTP_ORIGIN', ?, ?, '{}', ?, ?)`,
+        ).run(
+          randomUUID(),
+          networkId,
+          origin.id,
+          endpoint.evidence_artifact_id,
+          endpoint.created_at,
+        );
+      }
+      const webId = randomUUID();
+      db.prepare(`INSERT INTO nodes VALUES (?, 'web_endpoint', ?, ?, ?, ?, ?)`).run(
+        webId,
+        `webep:${origin.id}:${props.method}:${props.path}`,
+        JSON.stringify({
+          method: props.method,
+          path: props.path,
+          statusCode: props.statusCode,
+          contentLength: props.contentLength,
+        }),
+        endpoint.evidence_artifact_id,
+        endpoint.created_at,
+        endpoint.updated_at,
+      );
+      db.prepare(`INSERT INTO edges VALUES (?, 'HTTP_ORIGIN_WEB_ENDPOINT', ?, ?, '{}', ?, ?)`).run(
+        randomUUID(),
+        origin.id,
+        webId,
+        endpoint.evidence_artifact_id,
+        endpoint.created_at,
+      );
+    }
+  },
+};
+
+export default migration;

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -24,6 +24,9 @@ export const NODE_KINDS = [
   'vulnerability',
   'cve',
   'svc_observation',
+  'network_endpoint',
+  'http_origin',
+  'web_endpoint',
 ] as const;
 export type NodeKind = (typeof NODE_KINDS)[number];
 
@@ -41,6 +44,9 @@ export const EDGE_KINDS = [
   'INPUT_OBSERVATION',
   'VULNERABILITY_CVE',
   'VHOST_ENDPOINT',
+  'HOST_NETWORK_ENDPOINT',
+  'NETWORK_ENDPOINT_HTTP_ORIGIN',
+  'HTTP_ORIGIN_WEB_ENDPOINT',
 ] as const;
 export type EdgeKind = (typeof EDGE_KINDS)[number];
 
@@ -72,6 +78,29 @@ export const ServicePropsSchema = z.object({
   state: z.string().min(1),
 });
 export type ServiceProps = z.infer<typeof ServicePropsSchema>;
+
+export const NetworkEndpointPropsSchema = z.object({
+  transport: z.string().min(1),
+  port: z.number().int().min(0).max(65535),
+  state: z.string().min(1),
+  protocolHint: z.string().optional(),
+  banner: z.string().optional(),
+  product: z.string().optional(),
+  version: z.string().optional(),
+});
+
+export const HttpOriginPropsSchema = z.object({
+  scheme: z.enum(['http', 'https']),
+  hostname: z.string().min(1),
+  port: z.number().int().min(0).max(65535),
+});
+
+export const WebEndpointPropsSchema = z.object({
+  method: z.string().min(1),
+  path: z.string().min(1),
+  statusCode: z.number().int().optional(),
+  contentLength: z.number().int().optional(),
+});
 
 export const EndpointPropsSchema = z.object({
   baseUri: z.string().min(1),
@@ -148,6 +177,9 @@ const PROPS_SCHEMA_MAP: Record<NodeKind, z.ZodTypeAny> = {
   vulnerability: VulnerabilityPropsSchema,
   cve: CvePropsSchema,
   svc_observation: SvcObservationPropsSchema,
+  network_endpoint: NetworkEndpointPropsSchema,
+  http_origin: HttpOriginPropsSchema,
+  web_endpoint: WebEndpointPropsSchema,
 };
 
 // ============================================================
@@ -221,6 +253,15 @@ export function buildNaturalKey(kind: NodeKind, props: unknown, parentId?: strin
 
     case 'service':
       return `svc:${parentId}:${p.transport}:${p.port}`;
+
+    case 'network_endpoint':
+      return `net:${parentId}:${p.transport}:${p.port}`;
+
+    case 'http_origin':
+      return `origin:${parentId}:${p.scheme}:${p.hostname}:${p.port}`;
+
+    case 'web_endpoint':
+      return `webep:${parentId}:${p.method}:${p.path}`;
 
     case 'endpoint':
       return `ep:${parentId}:${p.method}:${p.path}`;

--- a/tests/db/migrations/v8.test.ts
+++ b/tests/db/migrations/v8.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { NodeRepository } from '../../../src/db/repository/node-repository.js';
+import { EdgeRepository } from '../../../src/db/repository/edge-repository.js';
+
+describe('Migration v8 HTTP graph model', () => {
+  it('同一Network Endpointに複数HTTP Originと同一Pathを登録できる', () => {
+    const db = new Database(':memory:');
+    migrateDatabase(db);
+    const nodes = new NodeRepository(db);
+    const edges = new EdgeRepository(db);
+    const host = nodes.create('host', { authorityKind: 'IP', authority: '10.0.0.1' });
+    const network = nodes.create(
+      'network_endpoint',
+      { transport: 'tcp', port: 8443, state: 'open', protocolHint: 'https' },
+      undefined,
+      host.id,
+    );
+    edges.create('HOST_NETWORK_ENDPOINT', host.id, network.id);
+    const originA = nodes.create(
+      'http_origin',
+      { scheme: 'https', hostname: 'a.example.test', port: 8443 },
+      undefined,
+      network.id,
+    );
+    const originB = nodes.create(
+      'http_origin',
+      { scheme: 'https', hostname: 'b.example.test', port: 8443 },
+      undefined,
+      network.id,
+    );
+    const endpointA = nodes.create(
+      'web_endpoint',
+      { method: 'GET', path: '/admin' },
+      undefined,
+      originA.id,
+    );
+    const endpointB = nodes.create(
+      'web_endpoint',
+      { method: 'GET', path: '/admin' },
+      undefined,
+      originB.id,
+    );
+
+    expect(originA.naturalKey).not.toBe(originB.naturalKey);
+    expect(endpointA.naturalKey).not.toBe(endpointB.naturalKey);
+  });
+
+  it('異なるWeb Endpointにある同名Inputを区別する', () => {
+    const db = new Database(':memory:');
+    migrateDatabase(db);
+    const nodes = new NodeRepository(db);
+    const first = nodes.create('input', { location: 'query', name: 'id' }, undefined, 'web-1');
+    const second = nodes.create('input', { location: 'query', name: 'id' }, undefined, 'web-2');
+    expect(first.naturalKey).not.toBe(second.naturalKey);
+  });
+});

--- a/tests/types/graph.test.ts
+++ b/tests/types/graph.test.ts
@@ -30,8 +30,8 @@ import {
 // ============================================================
 
 describe('NodeKind', () => {
-  it('10 種類のノード種別が定義されている', () => {
-    expect(NODE_KINDS).toHaveLength(10);
+  it('13 種類のノード種別が定義されている', () => {
+    expect(NODE_KINDS).toHaveLength(13);
   });
 
   it('全ノード種別が含まれている', () => {
@@ -54,8 +54,8 @@ describe('NodeKind', () => {
 });
 
 describe('EdgeKind', () => {
-  it('13 種類のエッジ種別が定義されている', () => {
-    expect(EDGE_KINDS).toHaveLength(13);
+  it('16 種類のエッジ種別が定義されている', () => {
+    expect(EDGE_KINDS).toHaveLength(16);
   });
 
   it('全エッジ種別が含まれている', () => {
@@ -344,6 +344,9 @@ describe('validateProps', () => {
       vulnerability: { vulnType: 'xss', title: 't', severity: 'high', confidence: 'high' },
       cve: { cveId: 'CVE-2021-0001' },
       svc_observation: { key: 'k', value: 'v', confidence: 'high' },
+      network_endpoint: { transport: 'tcp', port: 443, state: 'open' },
+      http_origin: { scheme: 'https', hostname: 'test.com', port: 443 },
+      web_endpoint: { method: 'GET', path: '/' },
     };
 
     for (const kind of NODE_KINDS) {


### PR DESCRIPTION
## 変更内容

- Network Endpoint、HTTP Origin、Web Endpoint Node
- 三種類の関連Edge
- Host、Transport、Port、Origin、Method、Pathに基づく自然キー
- 既存ServiceとEndpointから新モデルを生成するv8 Migration
- 複数Originの同一PathとEndpoint固有Inputのテスト
- README、AGENTS.md、Wikiの更新

既存Nodeは移行期間の証跡として残し、新モデルを並行して生成します。

## 検証

- format
- lint
- typecheck
- 421 tests
- build

Closes #40