### PR TITLE
Action Contextへ証跡、Finding、scope、先行Executionを統合する

### DIFF
--- a/src/db/repository/action-context-repository.ts
+++ b/src/db/repository/action-context-repository.ts
@@ -1,14 +1,33 @@
 import type Database from 'better-sqlite3';
-import type { ActionQueueItem, Mission } from '../../types/operational.js';
+import type {
+  ActionExecution,
+  ActionQueueItem,
+  Artifact,
+  Engagement,
+  Finding,
+  Mission,
+  ObservationRecord,
+} from '../../types/operational.js';
 import type { GraphEdge, GraphNode } from '../../types/graph.js';
 import { ActionQueueRepository } from './action-queue-repository.js';
 import { MissionRepository } from './mission-repository.js';
+import { EngagementRepository } from './engagement-repository.js';
+import { ActionExecutionRepository } from './action-execution-repository.js';
+import { ArtifactRepository } from './artifact-repository.js';
+import { FindingRepository } from './finding-repository.js';
+import { ObservationRepository } from './observation-repository.js';
 
 export interface ActionContext {
   action: ActionQueueItem;
   mission?: Mission;
+  engagement: Engagement;
+  parentAction?: ActionQueueItem;
+  executions: ActionExecution[];
   nodes: GraphNode[];
   edges: GraphEdge[];
+  observations: ObservationRecord[];
+  artifacts: Artifact[];
+  findings: Finding[];
 }
 
 interface ContextRow {
@@ -34,7 +53,7 @@ export class ActionContextRepository {
   get(
     actionId: string,
     targetNodeIds: string[],
-    options?: { edgeKinds?: string[]; depth?: number },
+    options?: { edgeKinds?: string[]; depth?: number; includeSensitive?: boolean },
   ): ActionContext | undefined {
     const action = new ActionQueueRepository(this.db).findById(actionId);
     if (action === undefined) return undefined;
@@ -42,8 +61,27 @@ export class ActionContextRepository {
       action.missionId === undefined
         ? undefined
         : new MissionRepository(this.db).findById(action.missionId);
-    if (targetNodeIds.length === 0)
-      return { action, ...(mission ? { mission } : {}), nodes: [], edges: [] };
+    const engagement = new EngagementRepository(this.db).findById(action.engagementId);
+    if (engagement === undefined) throw new Error(`Engagement not found: ${action.engagementId}`);
+    const parentAction =
+      action.parentActionId === undefined
+        ? undefined
+        : new ActionQueueRepository(this.db).findById(action.parentActionId);
+    const executions = new ActionExecutionRepository(this.db).findByAction(action.id);
+    if (targetNodeIds.length === 0) {
+      return {
+        action,
+        ...(mission ? { mission } : {}),
+        engagement,
+        ...(parentAction ? { parentAction } : {}),
+        executions,
+        nodes: [],
+        edges: [],
+        observations: [],
+        artifacts: this.findArtifacts(action.id, executions),
+        findings: [],
+      };
+    }
 
     const depth = Math.max(0, Math.min(options?.depth ?? 1, 10));
     const targetPlaceholders = targetNodeIds.map(() => '?').join(', ');
@@ -102,11 +140,98 @@ export class ActionContextRepository {
         });
       }
     }
+    if (options?.includeSensitive !== true) {
+      const credentialIds = [...nodes.values()]
+        .filter((node) => node.kind === 'credential')
+        .map((node) => node.id);
+      for (const id of credentialIds) nodes.delete(id);
+      for (const [id, edge] of edges) {
+        if (credentialIds.includes(edge.sourceId) || credentialIds.includes(edge.targetId)) {
+          edges.delete(id);
+        }
+      }
+    }
+    const nodeIds = [...nodes.keys()];
+    const edgeIds = [...edges.keys()];
+    const observationIds = this.findObservationIds(nodeIds, edgeIds);
+    const observationRepo = new ObservationRepository(this.db);
+    const observations = observationIds
+      .map((id) => observationRepo.findById(id))
+      .filter((value): value is ObservationRecord => value !== undefined);
+    const artifactIds = new Set(observations.map((item) => item.artifactId));
+    for (const node of nodes.values())
+      if (node.evidenceArtifactId) artifactIds.add(node.evidenceArtifactId);
+    for (const edge of edges.values())
+      if (edge.evidenceArtifactId) artifactIds.add(edge.evidenceArtifactId);
+    for (const artifact of this.findArtifacts(action.id, executions)) artifactIds.add(artifact.id);
+    const artifactRepo = new ArtifactRepository(this.db);
+    const artifacts = [...artifactIds]
+      .map((id) => artifactRepo.findById(id))
+      .filter((value): value is Artifact => value !== undefined)
+      .filter(
+        (artifact) => options?.includeSensitive === true || artifact.sensitivity !== 'secret',
+      );
+    const findingRows = this.db
+      .prepare(
+        `SELECT DISTINCT f.id FROM findings f
+         LEFT JOIN observation_findings ofn ON ofn.finding_id = f.id
+         WHERE f.engagement_id = ? AND (f.node_id IN (${nodeIds.map(() => '?').join(', ')})
+           OR ofn.observation_id IN (${observationIds.length === 0 ? "''" : observationIds.map(() => '?').join(', ')}))`,
+      )
+      .all(action.engagementId, ...nodeIds, ...observationIds) as Array<{ id: string }>;
+    const findingRepo = new FindingRepository(this.db);
+    const findings = findingRows
+      .map((row) => findingRepo.findById(row.id))
+      .filter((value): value is Finding => value !== undefined);
     return {
       action,
       ...(mission === undefined ? {} : { mission }),
+      engagement,
+      ...(parentAction === undefined ? {} : { parentAction }),
+      executions,
       nodes: [...nodes.values()],
       edges: [...edges.values()],
+      observations,
+      artifacts,
+      findings,
     };
+  }
+
+  private findObservationIds(nodeIds: string[], edgeIds: string[]): string[] {
+    const ids = new Set<string>();
+    if (nodeIds.length > 0) {
+      const rows = this.db
+        .prepare(
+          `SELECT observation_id FROM observation_nodes WHERE node_id IN (${nodeIds.map(() => '?').join(', ')})`,
+        )
+        .all(...nodeIds) as Array<{ observation_id: string }>;
+      for (const row of rows) ids.add(row.observation_id);
+    }
+    if (edgeIds.length > 0) {
+      const rows = this.db
+        .prepare(
+          `SELECT observation_id FROM observation_edges WHERE edge_id IN (${edgeIds.map(() => '?').join(', ')})`,
+        )
+        .all(...edgeIds) as Array<{ observation_id: string }>;
+      for (const row of rows) ids.add(row.observation_id);
+    }
+    return [...ids];
+  }
+
+  private findArtifacts(actionId: string, executions: ActionExecution[]): Artifact[] {
+    const executionIds = executions.map((item) => item.id);
+    const rows = this.db
+      .prepare(
+        `SELECT id FROM artifacts WHERE action_id = ?${
+          executionIds.length === 0
+            ? ''
+            : ` OR action_execution_id IN (${executionIds.map(() => '?').join(', ')})`
+        }`,
+      )
+      .all(actionId, ...executionIds) as Array<{ id: string }>;
+    const repo = new ArtifactRepository(this.db);
+    return rows
+      .map((row) => repo.findById(row.id))
+      .filter((value): value is Artifact => value !== undefined);
   }
 }

--- a/src/mcp/tools/missions.ts
+++ b/src/mcp/tools/missions.ts
@@ -24,6 +24,7 @@ export function registerMissionTool(server: McpServer, db: Database.Database): v
       targetNodeIds: z.array(z.string()).optional(),
       edgeKinds: z.array(z.string()).optional(),
       depth: z.number().int().min(0).max(10).optional(),
+      includeSensitive: z.boolean().optional(),
     },
     async (input) => {
       try {
@@ -77,6 +78,7 @@ export function registerMissionTool(server: McpServer, db: Database.Database): v
         const context = contexts.get(input.id, input.targetNodeIds ?? [], {
           edgeKinds: input.edgeKinds,
           depth: input.depth,
+          includeSensitive: input.includeSensitive,
         });
         if (!context) throw new Error(`Action not found: ${input.id}`);
         return { content: [{ type: 'text', text: JSON.stringify(context, null, 2) }] };

--- a/tests/db/repository/action-context-repository.test.ts
+++ b/tests/db/repository/action-context-repository.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+import { MissionRepository } from '../../../src/db/repository/mission-repository.js';
+import { ActionQueueRepository } from '../../../src/db/repository/action-queue-repository.js';
+import { ActionExecutionRepository } from '../../../src/db/repository/action-execution-repository.js';
+import { ObservationRepository } from '../../../src/db/repository/observation-repository.js';
+import { FindingRepository } from '../../../src/db/repository/finding-repository.js';
+import { ActionContextRepository } from '../../../src/db/repository/action-context-repository.js';
+
+describe('ActionContextRepository', () => {
+  it('scope、親Action、Execution、Observation、Artifact、Findingを返す', () => {
+    const db = new Database(':memory:');
+    migrateDatabase(db);
+    const engagement = new EngagementRepository(db).create({
+      name: 'test',
+      scopeJson: '{"hosts":["10.0.0.1"]}',
+      policyJson: '{"allowActiveTesting":true}',
+    });
+    const mission = new MissionRepository(db).create({
+      engagementId: engagement.id,
+      objective: '対象を調査する',
+    });
+    const actions = new ActionQueueRepository(db);
+    const parent = actions.enqueue({
+      engagementId: engagement.id,
+      missionId: mission.id,
+      kind: 'network_service_discovery',
+      dedupeKey: 'parent',
+    });
+    const action = actions.enqueue({
+      engagementId: engagement.id,
+      parentActionId: parent.id,
+      kind: 'web_endpoint_discovery',
+      dedupeKey: 'child',
+    });
+    const execution = new ActionExecutionRepository(db).create({
+      actionId: action.id,
+      executor: 'worker-1',
+    });
+    const artifactId = randomUUID();
+    db.prepare(
+      `INSERT INTO artifacts
+       (id, tool, kind, path, captured_at, engagement_id, mission_id, action_id,
+        action_execution_id, sensitivity)
+       VALUES (?, 'worker-1', 'stdout', 'artifact://stdout', ?, ?, ?, ?, ?, 'internal')`,
+    ).run(artifactId, new Date().toISOString(), engagement.id, mission.id, action.id, execution.id);
+    const observation = new ObservationRepository(db).record({
+      artifactId,
+      actor: 'worker-1',
+      content: { summary: 'host found' },
+      nodes: [{ ref: 'host', kind: 'host', props: { authorityKind: 'IP', authority: '10.0.0.1' } }],
+    });
+    const finding = new FindingRepository(db).upsert({
+      engagementId: engagement.id,
+      canonicalKey: 'host-exposed',
+      nodeId: observation.nodeIds[0],
+      title: 'Host exposed',
+      severity: 'info',
+      confidence: 'high',
+    }).finding;
+
+    const context = new ActionContextRepository(db).get(action.id, observation.nodeIds)!;
+
+    expect(context.engagement.scopeJson).toContain('10.0.0.1');
+    expect(context.parentAction?.id).toBe(parent.id);
+    expect(context.executions.map((item) => item.id)).toContain(execution.id);
+    expect(context.observations.map((item) => item.id)).toContain(observation.id);
+    expect(context.artifacts.map((item) => item.id)).toContain(artifactId);
+    expect(context.findings.map((item) => item.id)).toContain(finding.id);
+  });
+
+  it('Credentialとsecret Artifactは明示的に要求した場合だけ返す', () => {
+    const db = new Database(':memory:');
+    migrateDatabase(db);
+    const engagement = new EngagementRepository(db).create({ name: 'test' });
+    const mission = new MissionRepository(db).create({
+      engagementId: engagement.id,
+      objective: '認証を調査する',
+    });
+    const action = new ActionQueueRepository(db).enqueue({
+      engagementId: engagement.id,
+      missionId: mission.id,
+      kind: 'credential_validation',
+      dedupeKey: 'credential',
+    });
+    const artifactId = randomUUID();
+    db.prepare(
+      `INSERT INTO artifacts (id, tool, kind, path, captured_at, engagement_id, mission_id,
+       action_id, sensitivity) VALUES (?, 'worker', 'stdout', 'artifact://secret', ?, ?, ?, ?, 'secret')`,
+    ).run(artifactId, new Date().toISOString(), engagement.id, mission.id, action.id);
+    const observation = new ObservationRepository(db).record({
+      artifactId,
+      actor: 'worker',
+      content: {},
+      nodes: [
+        {
+          ref: 'credential',
+          kind: 'credential',
+          props: {
+            username: 'admin',
+            secret: 'value',
+            secretType: 'password',
+            source: 'worker',
+            confidence: 'high',
+          },
+        },
+      ],
+    });
+    const repo = new ActionContextRepository(db);
+
+    expect(repo.get(action.id, observation.nodeIds)?.nodes).toHaveLength(0);
+    const sensitive = repo.get(action.id, observation.nodeIds, { includeSensitive: true });
+    expect(sensitive?.nodes[0].kind).toBe('credential');
+    expect(sensitive?.artifacts[0].sensitivity).toBe('secret');
+  });
+});


### PR DESCRIPTION
## 変更内容

- Engagementのscopeとpolicy
- 親Actionと先行Execution
- 関連Observation、Artifact、Finding
- Graph NodeとEdgeの証跡収集
- Credentialとsecret Artifactの既定除外
- 明示的な機密情報取得オプション
- Repository統合テスト
- Wiki更新

## 検証

- format
- lint
- typecheck
- 423 tests
- build

Closes #42