### PR TITLE
MissionとActionの型付き対象参照とscope検証を追加する

### DIFF
--- a/src/db/repository/action-queue-repository.ts
+++ b/src/db/repository/action-queue-repository.ts
@@ -8,6 +8,8 @@
 import type Database from 'better-sqlite3';
 import crypto from 'node:crypto';
 import type { ActionQueueItem, CreateActionInput } from '../../types/operational.js';
+import { ActionParamsSchema } from '../../types/mission.js';
+import { TargetValidator } from './target-validator.js';
 
 // ---------------------------------------------------------------------------
 // DB row 型
@@ -196,7 +198,8 @@ export class ActionQueueRepository {
 
     const priority = input.priority ?? 100;
     const state = input.state ?? 'queued';
-    const paramsJson = input.paramsJson ?? '{}';
+    const params = ActionParamsSchema.parse(JSON.parse(input.paramsJson ?? '{}'));
+    const paramsJson = JSON.stringify(params);
     const maxAttempts = input.maxAttempts ?? 3;
     const availableAt = input.availableAt ?? now;
 
@@ -217,6 +220,16 @@ export class ActionQueueRepository {
     }
     const missionId = input.missionId ?? parent?.missionId;
     const runId = input.runId ?? parent?.runId;
+    if (missionId !== undefined) {
+      const mission = this.db
+        .prepare('SELECT engagement_id FROM missions WHERE id = ?')
+        .get(missionId) as { engagement_id: string } | undefined;
+      if (mission === undefined) throw new Error(`Mission not found: ${missionId}`);
+      if (mission.engagement_id !== input.engagementId) {
+        throw new Error('Action mission is outside engagement');
+      }
+    }
+    new TargetValidator(this.db).validate(input.engagementId, params.targets ?? []);
 
     this.insertStmt.run(
       id,

--- a/src/db/repository/mission-repository.ts
+++ b/src/db/repository/mission-repository.ts
@@ -1,6 +1,8 @@
 import type Database from 'better-sqlite3';
 import { randomUUID } from 'node:crypto';
 import type { CreateMissionInput, Mission } from '../../types/operational.js';
+import { TargetsSchema } from '../../types/mission.js';
+import { TargetValidator } from './target-validator.js';
 
 interface MissionRow {
   id: string;
@@ -43,7 +45,9 @@ export class MissionRepository {
     if (input.objective.trim() === '') throw new Error('objective must not be empty');
     const id = randomUUID();
     const createdAt = new Date().toISOString();
-    const targetsJson = parseJsonArray(input.targetsJson ?? '[]', 'targetsJson');
+    const targets = TargetsSchema.parse(JSON.parse(input.targetsJson ?? '[]'));
+    new TargetValidator(this.db).validate(input.engagementId, targets);
+    const targetsJson = JSON.stringify(targets);
     const successJson = parseJsonArray(
       input.successConditionsJson ?? '[]',
       'successConditionsJson',

--- a/src/db/repository/target-validator.ts
+++ b/src/db/repository/target-validator.ts
@@ -1,0 +1,73 @@
+import type Database from 'better-sqlite3';
+import { EngagementScopeSchema, type TargetRef } from '../../types/mission.js';
+
+export class TargetValidator {
+  constructor(private readonly db: Database.Database) {}
+
+  validate(engagementId: string, targets: TargetRef[]): void {
+    const engagement = this.db
+      .prepare('SELECT scope_json FROM engagements WHERE id = ?')
+      .get(engagementId) as { scope_json: string } | undefined;
+    if (engagement === undefined) throw new Error(`Engagement not found: ${engagementId}`);
+    const scope = EngagementScopeSchema.parse(JSON.parse(engagement.scope_json));
+    for (const target of targets) {
+      if (target.type === 'finding') {
+        const row = this.db
+          .prepare('SELECT engagement_id FROM findings WHERE id = ?')
+          .get(target.id) as { engagement_id: string } | undefined;
+        if (row === undefined) throw new Error(`Finding target not found: ${target.id}`);
+        if (row.engagement_id !== engagementId)
+          throw new Error('Finding target is outside engagement');
+      } else if (target.type === 'action') {
+        const row = this.db
+          .prepare('SELECT engagement_id FROM action_queue WHERE id = ?')
+          .get(target.id) as { engagement_id: string } | undefined;
+        if (row === undefined) throw new Error(`Action target not found: ${target.id}`);
+        if (row.engagement_id !== engagementId)
+          throw new Error('Action target is outside engagement');
+      } else {
+        this.validateNode(target.id, scope.nodeIds, scope.hostAuthorities);
+      }
+    }
+  }
+
+  private validateNode(id: string, nodeIds?: string[], hostAuthorities?: string[]): void {
+    const node = this.db.prepare('SELECT id, kind, props_json FROM nodes WHERE id = ?').get(id) as
+      | { id: string; kind: string; props_json: string }
+      | undefined;
+    if (node === undefined) throw new Error(`Node target not found: ${id}`);
+    if (nodeIds !== undefined && !this.isReachableFrom(id, nodeIds)) {
+      throw new Error(`Node target is outside engagement scope: ${id}`);
+    }
+    if (hostAuthorities !== undefined) {
+      const authorityRows = this.db
+        .prepare(
+          `WITH RECURSIVE ancestors(id) AS (
+             SELECT ? UNION
+             SELECT e.source_id FROM edges e JOIN ancestors a ON e.target_id = a.id
+           )
+           SELECT props_json FROM nodes WHERE id IN ancestors AND kind = 'host'`,
+        )
+        .all(id) as Array<{ props_json: string }>;
+      const matches = authorityRows.some((row) => {
+        const props = JSON.parse(row.props_json) as { authority?: string };
+        return props.authority !== undefined && hostAuthorities.includes(props.authority);
+      });
+      if (!matches) throw new Error(`Node target is outside engagement host scope: ${id}`);
+    }
+  }
+
+  private isReachableFrom(targetId: string, scopeNodeIds: string[]): boolean {
+    if (scopeNodeIds.includes(targetId)) return true;
+    if (scopeNodeIds.length === 0) return false;
+    const row = this.db
+      .prepare(
+        `WITH RECURSIVE reachable(id) AS (
+           SELECT id FROM nodes WHERE id IN (${scopeNodeIds.map(() => '?').join(', ')})
+           UNION SELECT e.target_id FROM edges e JOIN reachable r ON e.source_id = r.id
+         ) SELECT 1 ok FROM reachable WHERE id = ? LIMIT 1`,
+      )
+      .get(...scopeNodeIds, targetId) as { ok: number } | undefined;
+    return row !== undefined;
+  }
+}

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const TargetRefSchema = z.object({
+  type: z.enum(['node', 'finding', 'action']),
+  id: z.string().min(1),
+});
+export type TargetRef = z.infer<typeof TargetRefSchema>;
+
+export const TargetsSchema = z.array(TargetRefSchema);
+
+export const ActionParamsSchema = z
+  .object({
+    objective: z.string().min(1).optional(),
+    targets: TargetsSchema.optional(),
+    expectedOutputs: z.array(z.string().min(1)).optional(),
+    stopConditions: z.array(z.string().min(1)).optional(),
+  })
+  .passthrough();
+
+export const EngagementScopeSchema = z
+  .object({
+    nodeIds: z.array(z.string().min(1)).optional(),
+    hostAuthorities: z.array(z.string().min(1)).optional(),
+  })
+  .passthrough();

--- a/tests/db/repository/action-queue-repository.test.ts
+++ b/tests/db/repository/action-queue-repository.test.ts
@@ -40,6 +40,16 @@ describe('ActionQueueRepository', () => {
   // =======================================================================
 
   describe('enqueue()', () => {
+    it('Actionの型付き対象参照を検証する', () => {
+      expect(() =>
+        repo.enqueue({
+          engagementId,
+          kind: 'test',
+          dedupeKey: 'invalid-target',
+          paramsJson: '{"targets":[{"type":"node","id":"missing"}]}',
+        }),
+      ).toThrow(/Node target not found/);
+    });
     it('基本作成 — creates an action with all fields and correct defaults', () => {
       const item = repo.enqueue({
         engagementId,

--- a/tests/db/repository/mission-repository.test.ts
+++ b/tests/db/repository/mission-repository.test.ts
@@ -4,6 +4,7 @@ import { migrateDatabase } from '../../../src/db/migrate.js';
 import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
 import { MissionRepository } from '../../../src/db/repository/mission-repository.js';
 import { ActionQueueRepository } from '../../../src/db/repository/action-queue-repository.js';
+import { NodeRepository } from '../../../src/db/repository/node-repository.js';
 
 describe('MissionRepository', () => {
   let db: InstanceType<typeof Database>;
@@ -16,10 +17,14 @@ describe('MissionRepository', () => {
   });
 
   it('Missionを作成し、所属Actionを登録できる', () => {
+    const target = new NodeRepository(db).create('host', {
+      authorityKind: 'IP',
+      authority: '10.0.0.1',
+    });
     const mission = new MissionRepository(db).create({
       engagementId,
       objective: 'Webの攻撃面を明らかにする',
-      targetsJson: '[{"type":"node","id":"target-1"}]',
+      targetsJson: JSON.stringify([{ type: 'node', id: target.id }]),
       successConditionsJson: '["Endpointを記録する"]',
     });
     const action = new ActionQueueRepository(db).enqueue({
@@ -31,6 +36,35 @@ describe('MissionRepository', () => {
 
     expect(mission.status).toBe('active');
     expect(action.missionId).toBe(mission.id);
+  });
+
+  it('Engagementのhost scope外にあるNodeを拒否する', () => {
+    const scopedEngagement = new EngagementRepository(db).create({
+      name: 'scoped',
+      scopeJson: '{"hostAuthorities":["10.0.0.1"]}',
+    });
+    const outside = new NodeRepository(db).create('host', {
+      authorityKind: 'IP',
+      authority: '10.0.0.2',
+    });
+
+    expect(() =>
+      new MissionRepository(db).create({
+        engagementId: scopedEngagement.id,
+        objective: 'scope外を調査する',
+        targetsJson: JSON.stringify([{ type: 'node', id: outside.id }]),
+      }),
+    ).toThrow(/outside engagement host scope/);
+  });
+
+  it('型が不正な対象参照を拒否する', () => {
+    expect(() =>
+      new MissionRepository(db).create({
+        engagementId,
+        objective: '不正な対象',
+        targetsJson: '[{"type":"port","id":"80"}]',
+      }),
+    ).toThrow();
   });
 
   it('子Actionは親のMissionとRunを継承する', () => {


### PR DESCRIPTION
## 変更内容

- node、finding、actionの型付き対象参照
- MissionとAction paramsのZod検証
- 参照先の存在確認
- FindingとActionのEngagement所属確認
- nodeIds scopeの子孫判定
- hostAuthorities scopeの祖先Host判定
- 親ActionとMissionのEngagement整合性
- Wiki更新

空のscopeは既存動作と同じく制限なしです。

## 検証

- format
- lint
- typecheck
- 426 tests
- build

Closes #43