### PR TITLE
Artifact保存のセキュリティ境界を強化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,5 +99,7 @@ stdio の既存利用者を壊さない構成にする。
 
 - `SONOBAT_DB_PATH`: SQLite DB path。既定値は `sonobat.db`
 - `SONOBAT_DATA_DIR`: HackTricks 等の data root。既定値は `~/.sonobat/data/`
+- `SONOBAT_ARTIFACT_DIR`: Artifact の保存を許可する root。既定値は `~/.sonobat/artifacts/`
+- `SONOBAT_ARTIFACT_MAX_BYTES`: Artifact 一件の最大 byte 数。既定値は `10485760`
 
 将来の HTTP/DB 選択用設定名は、実装と同時に定義し、README とこの文書を更新すること。

--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ npx @modelcontextprotocol/inspector npx tsx src/index.ts
 |----------|---------|-------------|
 | `SONOBAT_DB_PATH` | `sonobat.db` | Path to the SQLite database file |
 | `SONOBAT_DATA_DIR` | `~/.sonobat/data/` | Root data directory for auto-cloned repositories |
+| `SONOBAT_ARTIFACT_DIR` | `~/.sonobat/artifacts/` | Allowed root directory for managed artifacts |
+| `SONOBAT_ARTIFACT_MAX_BYTES` | `10485760` | Maximum size of one artifact in bytes |
 
 ## Tech Stack
 

--- a/src/db/repository/action-context-repository.ts
+++ b/src/db/repository/action-context-repository.ts
@@ -166,7 +166,7 @@ export class ActionContextRepository {
     for (const artifact of this.findArtifacts(action.id, executions)) artifactIds.add(artifact.id);
     const artifactRepo = new ArtifactRepository(this.db);
     const artifacts = [...artifactIds]
-      .map((id) => artifactRepo.findById(id))
+      .map((id) => artifactRepo.findById(id, { includeSensitive: true }))
       .filter((value): value is Artifact => value !== undefined)
       .filter(
         (artifact) => options?.includeSensitive === true || artifact.sensitivity !== 'secret',
@@ -231,7 +231,7 @@ export class ActionContextRepository {
       .all(actionId, ...executionIds) as Array<{ id: string }>;
     const repo = new ArtifactRepository(this.db);
     return rows
-      .map((row) => repo.findById(row.id))
+      .map((row) => repo.findById(row.id, { includeSensitive: true }))
       .filter((value): value is Artifact => value !== undefined);
   }
 }

--- a/src/db/repository/artifact-repository.ts
+++ b/src/db/repository/artifact-repository.ts
@@ -1,6 +1,27 @@
 import type Database from 'better-sqlite3';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import type { Artifact } from '../../types/operational.js';
+
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
+
+export interface ArtifactRepositoryOptions {
+  rootDir?: string;
+  maxBytes?: number;
+}
+
+export interface FindArtifactOptions {
+  includeSensitive?: boolean;
+}
 
 interface ArtifactRow {
   id: string;
@@ -39,7 +60,25 @@ function toArtifact(row: ArtifactRow): Artifact {
 }
 
 export class ArtifactRepository {
-  constructor(private readonly db: Database.Database) {}
+  private readonly rootDir: string;
+  private readonly maxBytes: number;
+
+  constructor(
+    private readonly db: Database.Database,
+    options: ArtifactRepositoryOptions = {},
+  ) {
+    const configuredRoot = resolve(
+      options.rootDir ??
+        process.env.SONOBAT_ARTIFACT_DIR ??
+        join(homedir(), '.sonobat', 'artifacts'),
+    );
+    mkdirSync(configuredRoot, { recursive: true, mode: 0o700 });
+    this.rootDir = realpathSync(configuredRoot);
+    this.maxBytes = options.maxBytes ?? parseMaxBytes(process.env.SONOBAT_ARTIFACT_MAX_BYTES);
+    if (!Number.isSafeInteger(this.maxBytes) || this.maxBytes <= 0) {
+      throw new Error('Artifact maxBytes must be a positive safe integer');
+    }
+  }
 
   create(input: {
     engagementId: string;
@@ -54,6 +93,7 @@ export class ArtifactRepository {
     mediaType?: string;
     sensitivity?: string;
     attrsJson?: string;
+    contentBase64?: string;
   }): Artifact {
     if (input.kind.trim() === '' || input.path.trim() === '') {
       throw new Error('Artifact kind and path must not be empty');
@@ -63,37 +103,128 @@ export class ArtifactRepository {
       throw new Error('attrsJson must be a JSON object');
     }
     const id = randomUUID();
+    const stored = this.prepareArtifact(id, input.path, input.contentBase64, input.sha256);
     const capturedAt = new Date().toISOString();
-    this.db
-      .prepare(
-        `INSERT INTO artifacts
-         (id, tool, kind, path, sha256, captured_at, attrs_json, engagement_id, run_id,
-          mission_id, action_id, action_execution_id, media_type, sensitivity)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        id,
-        input.producer,
-        input.kind,
-        input.path,
-        input.sha256 ?? null,
-        capturedAt,
-        JSON.stringify(attrs),
-        input.engagementId,
-        input.runId ?? null,
-        input.missionId ?? null,
-        input.actionId,
-        input.actionExecutionId,
-        input.mediaType ?? null,
-        input.sensitivity ?? 'internal',
-      );
-    return this.findById(id)!;
+    try {
+      this.db
+        .prepare(
+          `INSERT INTO artifacts
+           (id, tool, kind, path, sha256, captured_at, attrs_json, engagement_id, run_id,
+            mission_id, action_id, action_execution_id, media_type, sensitivity)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          id,
+          input.producer,
+          input.kind,
+          stored.path,
+          stored.sha256,
+          capturedAt,
+          JSON.stringify(attrs),
+          input.engagementId,
+          input.runId ?? null,
+          input.missionId ?? null,
+          input.actionId,
+          input.actionExecutionId,
+          input.mediaType ?? null,
+          input.sensitivity ?? 'internal',
+        );
+    } catch (error) {
+      if (stored.created) unlinkSync(stored.path);
+      throw error;
+    }
+    return this.findById(id, { includeSensitive: true })!;
   }
 
-  findById(id: string): Artifact | undefined {
+  findById(id: string, options: FindArtifactOptions = {}): Artifact | undefined {
     const row = this.db.prepare('SELECT * FROM artifacts WHERE id = ?').get(id) as
       | ArtifactRow
       | undefined;
-    return row === undefined ? undefined : toArtifact(row);
+    if (row === undefined || (row.sensitivity === 'secret' && !options.includeSensitive)) {
+      return undefined;
+    }
+    return toArtifact(row);
+  }
+
+  private prepareArtifact(
+    id: string,
+    requestedPath: string,
+    contentBase64: string | undefined,
+    expectedSha256: string | undefined,
+  ): { path: string; sha256: string; created: boolean } {
+    if (contentBase64 !== undefined) {
+      const content = decodeBase64(contentBase64);
+      this.requireAllowedSize(content.byteLength);
+      const sha256 = digest(content);
+      requireMatchingDigest(expectedSha256, sha256);
+      const name = basename(requestedPath);
+      if (name === '.' || name === sep || name.trim() === '') {
+        throw new Error('Artifact path must include a file name');
+      }
+      const storedPath = join(this.rootDir, id, name);
+      mkdirSync(join(this.rootDir, id), { recursive: true });
+      writeFileSync(storedPath, content, { flag: 'wx', mode: 0o600 });
+      return { path: storedPath, sha256, created: true };
+    }
+
+    if (!isAbsolute(requestedPath)) {
+      throw new Error('Existing Artifact path must be absolute');
+    }
+    const storedPath = realpathSync(resolve(requestedPath));
+    this.requireInsideRoot(storedPath);
+    const stats = statSync(storedPath);
+    if (!stats.isFile()) throw new Error('Artifact path must refer to a regular file');
+    this.requireAllowedSize(stats.size);
+    const sha256 = digest(readFileSync(storedPath));
+    requireMatchingDigest(expectedSha256, sha256);
+    return { path: storedPath, sha256, created: false };
+  }
+
+  private requireInsideRoot(path: string): void {
+    const child = relative(this.rootDir, path);
+    if (child === '' || child === '..' || child.startsWith(`..${sep}`) || isAbsolute(child)) {
+      throw new Error('Artifact path is outside the allowed root');
+    }
+  }
+
+  private requireAllowedSize(size: number): void {
+    if (size > this.maxBytes) {
+      throw new Error(`Artifact exceeds the maximum size of ${this.maxBytes} bytes`);
+    }
+  }
+}
+
+function parseMaxBytes(value: string | undefined): number {
+  if (value === undefined) return DEFAULT_MAX_BYTES;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error('SONOBAT_ARTIFACT_MAX_BYTES must be a positive safe integer');
+  }
+  return parsed;
+}
+
+function decodeBase64(value: string): Buffer {
+  const normalized = value.replace(/\s/g, '');
+  if (
+    normalized.length === 0 ||
+    normalized.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)
+  ) {
+    throw new Error('contentBase64 must be valid Base64');
+  }
+  const content = Buffer.from(normalized, 'base64');
+  if (content.toString('base64') !== normalized) {
+    throw new Error('contentBase64 must be canonical Base64');
+  }
+  return content;
+}
+
+function digest(content: Buffer): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function requireMatchingDigest(expected: string | undefined, actual: string): void {
+  if (expected !== undefined && expected.toLowerCase() !== actual) {
+    throw new Error('Artifact SHA-256 does not match its content');
   }
 }

--- a/src/db/repository/worker-lifecycle-repository.ts
+++ b/src/db/repository/worker-lifecycle-repository.ts
@@ -1,7 +1,7 @@
 import type Database from 'better-sqlite3';
 import { ActionExecutionRepository } from './action-execution-repository.js';
 import { ActionQueueRepository } from './action-queue-repository.js';
-import { ArtifactRepository } from './artifact-repository.js';
+import { ArtifactRepository, type ArtifactRepositoryOptions } from './artifact-repository.js';
 import type {
   ActionExecution,
   ActionQueueItem,
@@ -38,10 +38,13 @@ export class WorkerLifecycleRepository {
     action: ActionQueueItem;
   };
 
-  constructor(private readonly db: Database.Database) {
+  constructor(
+    private readonly db: Database.Database,
+    artifactOptions: ArtifactRepositoryOptions = {},
+  ) {
     this.executions = new ActionExecutionRepository(db);
     this.actions = new ActionQueueRepository(db);
-    this.artifacts = new ArtifactRepository(db);
+    this.artifacts = new ArtifactRepository(db, artifactOptions);
     this.finishTx = this.db.transaction((input: FinishExecutionInput) => {
       const execution = this.requireActiveExecution(input.executionId, input.leaseOwner);
       if (input.outputJson !== undefined) JSON.parse(input.outputJson);
@@ -102,6 +105,7 @@ export class WorkerLifecycleRepository {
       mediaType: input.mediaType,
       sensitivity: input.sensitivity,
       attrsJson: input.attrsJson,
+      contentBase64: input.contentBase64,
     });
   }
 

--- a/src/mcp/tools/worker.ts
+++ b/src/mcp/tools/worker.ts
@@ -31,6 +31,7 @@ export function registerWorkerTool(server: McpServer, db: Database.Database): vo
       mediaType: z.string().optional(),
       sensitivity: z.string().optional(),
       attrsJson: z.string().optional(),
+      contentBase64: z.string().optional(),
     },
     async (input) => {
       try {
@@ -67,6 +68,7 @@ export function registerWorkerTool(server: McpServer, db: Database.Database): vo
             mediaType: input.mediaType,
             sensitivity: input.sensitivity,
             attrsJson: input.attrsJson,
+            contentBase64: input.contentBase64,
           });
           return { content: [{ type: 'text', text: JSON.stringify(artifact, null, 2) }] };
         }

--- a/src/types/operational.ts
+++ b/src/types/operational.ts
@@ -118,6 +118,7 @@ export type RegisterArtifactInput = {
   mediaType?: string;
   sensitivity?: string;
   attrsJson?: string;
+  contentBase64?: string;
 };
 
 // ============================================================

--- a/tests/db/repository/artifact-repository.test.ts
+++ b/tests/db/repository/artifact-repository.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { ArtifactRepository } from '../../../src/db/repository/artifact-repository.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+import { ActionQueueRepository } from '../../../src/db/repository/action-queue-repository.js';
+import { ActionExecutionRepository } from '../../../src/db/repository/action-execution-repository.js';
+
+describe('ArtifactRepository', () => {
+  let db: InstanceType<typeof Database>;
+  let rootDir: string;
+  let input: {
+    engagementId: string;
+    actionId: string;
+    actionExecutionId: string;
+    producer: string;
+    kind: string;
+    path: string;
+  };
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migrateDatabase(db);
+    rootDir = mkdtempSync(join(tmpdir(), 'sonobat-artifact-test-'));
+    const engagement = new EngagementRepository(db).create({ name: 'test' });
+    const action = new ActionQueueRepository(db).enqueue({
+      engagementId: engagement.id,
+      kind: 'test',
+      dedupeKey: 'artifact-test',
+    });
+    const execution = new ActionExecutionRepository(db).create({
+      actionId: action.id,
+      executor: 'worker-1',
+    });
+    input = {
+      engagementId: engagement.id,
+      actionId: action.id,
+      actionExecutionId: execution.id,
+      producer: 'worker-1',
+      kind: 'stdout',
+      path: 'stdout.txt',
+    };
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('Base64内容を管理領域へ保存しSHA-256を記録する', () => {
+    const content = Buffer.from('hello artifact');
+    const repo = new ArtifactRepository(db, { rootDir });
+
+    const artifact = repo.create({ ...input, contentBase64: content.toString('base64') });
+
+    expect(readFileSync(artifact.path)).toEqual(content);
+    expect(artifact.sha256).toBe(createHash('sha256').update(content).digest('hex'));
+  });
+
+  it('管理領域外の既存ファイルを拒否する', () => {
+    const outside = join(tmpdir(), `sonobat-outside-${crypto.randomUUID()}.txt`);
+    writeFileSync(outside, 'outside');
+    const repo = new ArtifactRepository(db, { rootDir });
+    try {
+      expect(() => repo.create({ ...input, path: outside })).toThrow(/outside the allowed root/);
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
+  it('管理領域外を指すシンボリックリンクを拒否する', () => {
+    const outside = join(tmpdir(), `sonobat-outside-${crypto.randomUUID()}.txt`);
+    const link = join(rootDir, 'outside-link.txt');
+    writeFileSync(outside, 'outside');
+    symlinkSync(outside, link);
+    const repo = new ArtifactRepository(db, { rootDir });
+    try {
+      expect(() => repo.create({ ...input, path: link })).toThrow(/outside the allowed root/);
+    } finally {
+      rmSync(outside, { force: true });
+    }
+  });
+
+  it('上限を超える内容と一致しないSHA-256を拒否する', () => {
+    const repo = new ArtifactRepository(db, { rootDir, maxBytes: 3 });
+    expect(() =>
+      repo.create({ ...input, contentBase64: Buffer.from('four').toString('base64') }),
+    ).toThrow(/maximum size/);
+
+    expect(() =>
+      new ArtifactRepository(db, { rootDir }).create({
+        ...input,
+        contentBase64: Buffer.from('data').toString('base64'),
+        sha256: '0'.repeat(64),
+      }),
+    ).toThrow(/does not match/);
+  });
+
+  it('管理領域内の既存ファイルを検証して登録する', () => {
+    const directory = join(rootDir, 'existing');
+    mkdirSync(directory);
+    const path = join(directory, 'result.json');
+    writeFileSync(path, '{"ok":true}', { mode: 0o600 });
+
+    const artifact = new ArtifactRepository(db, { rootDir }).create({ ...input, path });
+
+    expect(artifact.path).toBe(path);
+    expect(artifact.sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('secretは明示的に許可した取得だけに返す', () => {
+    const repo = new ArtifactRepository(db, { rootDir });
+    const artifact = repo.create({
+      ...input,
+      sensitivity: 'secret',
+      contentBase64: Buffer.from('secret').toString('base64'),
+    });
+
+    expect(repo.findById(artifact.id)).toBeUndefined();
+    expect(repo.findById(artifact.id, { includeSensitive: true })?.id).toBe(artifact.id);
+  });
+});

--- a/tests/db/repository/worker-lifecycle-repository.test.ts
+++ b/tests/db/repository/worker-lifecycle-repository.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import Database from 'better-sqlite3';
 import { migrateDatabase } from '../../../src/db/migrate.js';
 import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
@@ -12,9 +15,11 @@ describe('WorkerLifecycleRepository', () => {
   let lifecycle: WorkerLifecycleRepository;
   let actionId: string;
   let missionId: string;
+  let artifactRoot: string;
 
   beforeEach(() => {
     db = new Database(':memory:');
+    artifactRoot = mkdtempSync(join(tmpdir(), 'sonobat-worker-test-'));
     migrateDatabase(db);
     const engagement = new EngagementRepository(db).create({ name: 'test' });
     const mission = new MissionRepository(db).create({
@@ -31,7 +36,12 @@ describe('WorkerLifecycleRepository', () => {
     });
     actionId = action.id;
     actions.poll('worker-1');
-    lifecycle = new WorkerLifecycleRepository(db);
+    lifecycle = new WorkerLifecycleRepository(db, { rootDir: artifactRoot });
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(artifactRoot, { recursive: true, force: true });
   });
 
   it('lease所有者がExecutionを開始してArtifactを登録できる', () => {
@@ -45,14 +55,16 @@ describe('WorkerLifecycleRepository', () => {
       executionId: execution.id,
       leaseOwner: 'worker-1',
       kind: 'stdout',
-      path: 'artifact://stdout',
-      sha256: 'abc123',
+      path: 'stdout.txt',
+      contentBase64: Buffer.from('command output').toString('base64'),
       mediaType: 'text/plain',
     });
 
     expect(artifact.actionId).toBe(actionId);
     expect(artifact.missionId).toBe(missionId);
     expect(artifact.actionExecutionId).toBe(execution.id);
+    expect(artifact.path.startsWith(artifactRoot)).toBe(true);
+    expect(artifact.sha256).toMatch(/^[a-f0-9]{64}$/);
   });
 
   it('別WorkerのleaseではExecutionを開始できない', () => {

--- a/tests/mcp/tools/worker.test.ts
+++ b/tests/mcp/tools/worker.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import Database from 'better-sqlite3';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
@@ -12,9 +15,14 @@ describe('worker MCP tool', () => {
   let db: InstanceType<typeof Database>;
   let client: Client;
   let actionId: string;
+  let artifactRoot: string;
+  let previousArtifactRoot: string | undefined;
 
   beforeEach(async () => {
     db = new Database(':memory:');
+    artifactRoot = mkdtempSync(join(tmpdir(), 'sonobat-mcp-worker-test-'));
+    previousArtifactRoot = process.env.SONOBAT_ARTIFACT_DIR;
+    process.env.SONOBAT_ARTIFACT_DIR = artifactRoot;
     migrateDatabase(db);
     const engagement = new EngagementRepository(db).create({ name: 'test' });
     const mission = new MissionRepository(db).create({
@@ -39,6 +47,10 @@ describe('worker MCP tool', () => {
 
   afterEach(async () => {
     await client.close();
+    db.close();
+    rmSync(artifactRoot, { recursive: true, force: true });
+    if (previousArtifactRoot === undefined) delete process.env.SONOBAT_ARTIFACT_DIR;
+    else process.env.SONOBAT_ARTIFACT_DIR = previousArtifactRoot;
   });
 
   it('Execution、Artifact、Action完了を記録する', async () => {
@@ -62,7 +74,8 @@ describe('worker MCP tool', () => {
         executionId: execution.id,
         leaseOwner: 'worker-1',
         kind: 'stdout',
-        path: 'artifact://stdout',
+        path: 'stdout.txt',
+        contentBase64: Buffer.from('command output').toString('base64'),
       },
     });
     expect(registered.isError).not.toBe(true);


### PR DESCRIPTION
## 変更内容

- Artifactを許可root配下へ保存し、容量上限とSHA-256を検証
- Base64内容から標準出力、標準エラーなどを管理領域へ保存
- 管理領域外のパスとシンボリックリンク経由の逸脱を拒否
- secret Artifactを通常取得から除外
- 環境変数とWikiを更新

## 検証

- npm run format
- npm run lint
- npm run typecheck
- npm test（432 tests）
- npm run build

Closes #44