### PR TITLE
ObservationとFindingを原子的に反映

### DIFF
--- a/src/db/repository/finding-repository.ts
+++ b/src/db/repository/finding-repository.ts
@@ -196,7 +196,7 @@ export class FindingRepository {
           're_observed',
           '{}',
           '{}',
-          null,
+          inp.artifactId ?? null,
           now,
         );
 
@@ -236,7 +236,7 @@ export class FindingRepository {
           'discovered',
           '{}',
           '{}',
-          null,
+          inp.artifactId ?? null,
           now,
         );
 

--- a/src/db/repository/observation-repository.ts
+++ b/src/db/repository/observation-repository.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { buildNaturalKey, EDGE_KINDS, NODE_KINDS, validateProps } from '../../types/graph.js';
 import type { EdgeKind, NodeKind } from '../../types/graph.js';
 import type { ObservationRecord } from '../../types/operational.js';
+import { FindingRepository } from './finding-repository.js';
 
 const ObservationInputSchema = z.object({
   artifactId: z.string().min(1),
@@ -31,6 +32,19 @@ const ObservationInputSchema = z.object({
     )
     .default([]),
   findingIds: z.array(z.string().min(1)).default([]),
+  findings: z
+    .array(
+      z.object({
+        canonicalKey: z.string().min(1),
+        title: z.string().min(1),
+        severity: z.string().min(1),
+        confidence: z.string().min(1),
+        state: z.string().min(1).optional(),
+        nodeRef: z.string().min(1).optional(),
+        attrs: z.record(z.string(), z.unknown()).default({}),
+      }),
+    )
+    .default([]),
 });
 
 export type CreateObservationInput = z.input<typeof ObservationInputSchema>;
@@ -157,6 +171,45 @@ export class ObservationRepository {
           .run(observationId, findingId);
       }
 
+      const artifact = this.db
+        .prepare('SELECT engagement_id, run_id FROM artifacts WHERE id = ?')
+        .get(input.artifactId) as
+        | { engagement_id: string | null; run_id: string | null }
+        | undefined;
+      if (artifact === undefined) throw new Error(`Artifact not found: ${input.artifactId}`);
+      if (input.findings.length > 0 && artifact.engagement_id === null) {
+        throw new Error('Artifact must belong to an Engagement when creating Findings');
+      }
+      const findingIds = [...input.findingIds];
+      const findings = new FindingRepository(this.db);
+      for (const findingInput of input.findings) {
+        const nodeId =
+          findingInput.nodeRef === undefined
+            ? undefined
+            : (refs.get(findingInput.nodeRef) ?? findingInput.nodeRef);
+        if (nodeId !== undefined) {
+          const node = this.db.prepare('SELECT 1 FROM nodes WHERE id = ?').get(nodeId);
+          if (node === undefined)
+            throw new Error(`Finding node not found: ${findingInput.nodeRef}`);
+        }
+        const result = findings.upsert({
+          engagementId: artifact.engagement_id!,
+          canonicalKey: findingInput.canonicalKey,
+          title: findingInput.title,
+          severity: findingInput.severity,
+          confidence: findingInput.confidence,
+          state: findingInput.state,
+          nodeId,
+          runId: artifact.run_id ?? undefined,
+          attrsJson: JSON.stringify(findingInput.attrs),
+          artifactId: input.artifactId,
+        });
+        findingIds.push(result.finding.id);
+        this.db
+          .prepare('INSERT INTO observation_findings (observation_id, finding_id) VALUES (?, ?)')
+          .run(observationId, result.finding.id);
+      }
+
       return {
         id: observationId,
         artifactId: input.artifactId,
@@ -165,7 +218,7 @@ export class ObservationRepository {
         ...(input.confidence === undefined ? {} : { confidence: input.confidence }),
         nodeIds,
         edgeIds,
-        findingIds: input.findingIds,
+        findingIds,
         createdAt,
       };
     });

--- a/src/mcp/tools/observations.ts
+++ b/src/mcp/tools/observations.ts
@@ -16,6 +16,7 @@ export function registerObservationTool(server: McpServer, db: Database.Database
       nodesJson: z.string().optional(),
       edgesJson: z.string().optional(),
       findingIds: z.array(z.string()).optional(),
+      findingsJson: z.string().optional(),
     },
     async (input) => {
       try {
@@ -27,6 +28,8 @@ export function registerObservationTool(server: McpServer, db: Database.Database
           nodes: input.nodesJson === undefined ? [] : (JSON.parse(input.nodesJson) as never[]),
           edges: input.edgesJson === undefined ? [] : (JSON.parse(input.edgesJson) as never[]),
           findingIds: input.findingIds ?? [],
+          findings:
+            input.findingsJson === undefined ? [] : (JSON.parse(input.findingsJson) as never[]),
         });
         return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
       } catch (error) {

--- a/src/types/operational.ts
+++ b/src/types/operational.ts
@@ -224,6 +224,7 @@ export type UpsertFindingInput = {
   state?: string;
   runId?: string;
   attrsJson?: string;
+  artifactId?: string;
 };
 
 // ============================================================

--- a/tests/db/repository/observation-repository.test.ts
+++ b/tests/db/repository/observation-repository.test.ts
@@ -3,19 +3,22 @@ import Database from 'better-sqlite3';
 import { randomUUID } from 'node:crypto';
 import { migrateDatabase } from '../../../src/db/migrate.js';
 import { ObservationRepository } from '../../../src/db/repository/observation-repository.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
 
 describe('ObservationRepository', () => {
   let db: InstanceType<typeof Database>;
   let artifactId: string;
+  let engagementId: string;
 
   beforeEach(() => {
     db = new Database(':memory:');
     migrateDatabase(db);
+    engagementId = new EngagementRepository(db).create({ name: 'test' }).id;
     artifactId = randomUUID();
     db.prepare(
-      `INSERT INTO artifacts (id, tool, kind, path, captured_at)
-       VALUES (?, 'worker', 'tool_output', '/tmp/result', ?)`,
-    ).run(artifactId, new Date().toISOString());
+      `INSERT INTO artifacts (id, tool, kind, path, captured_at, engagement_id)
+       VALUES (?, 'worker', 'tool_output', '/tmp/result', ?, ?)`,
+    ).run(artifactId, new Date().toISOString(), engagementId);
   });
 
   it('ObservationとCredential NodeとEdgeを一つの操作で保存する', () => {
@@ -115,5 +118,113 @@ describe('ObservationRepository', () => {
     expect(db.prepare("SELECT COUNT(*) count FROM nodes WHERE kind = 'credential'").get()).toEqual({
       count: 1,
     });
+  });
+
+  it('ObservationとFindingを一つの操作で作成しArtifactを根拠に記録する', () => {
+    const result = new ObservationRepository(db).record({
+      artifactId,
+      actor: 'worker-1',
+      content: { summary: 'critical service exposed' },
+      nodes: [
+        {
+          ref: 'host',
+          kind: 'host',
+          props: { authorityKind: 'IP', authority: '10.0.0.3' },
+        },
+      ],
+      findings: [
+        {
+          canonicalKey: 'exposed-service:10.0.0.3',
+          title: 'Critical service is exposed',
+          severity: 'critical',
+          confidence: 'high',
+          nodeRef: 'host',
+          attrs: { source: 'observation' },
+        },
+      ],
+    });
+
+    expect(result.findingIds).toHaveLength(1);
+    expect(
+      db
+        .prepare('SELECT engagement_id, node_id FROM findings WHERE id = ?')
+        .get(result.findingIds[0]),
+    ).toEqual({ engagement_id: engagementId, node_id: result.nodeIds[0] });
+    expect(
+      db
+        .prepare('SELECT artifact_id FROM finding_events WHERE finding_id = ?')
+        .get(result.findingIds[0]),
+    ).toEqual({ artifact_id: artifactId });
+  });
+
+  it('同じcanonical keyのFindingを更新して各Observationへ関連付ける', () => {
+    const repo = new ObservationRepository(db);
+    const common = {
+      artifactId,
+      actor: 'worker-1',
+      findings: [
+        {
+          canonicalKey: 'finding:shared',
+          title: 'Initial title',
+          severity: 'medium',
+          confidence: 'medium',
+        },
+      ],
+    };
+    const first = repo.record({ ...common, content: { pass: 1 } });
+    const second = repo.record({
+      ...common,
+      content: { pass: 2 },
+      findings: [{ ...common.findings[0], title: 'Updated title', severity: 'high' }],
+    });
+
+    expect(second.findingIds).toEqual(first.findingIds);
+    expect(db.prepare('SELECT title, severity FROM findings').get()).toEqual({
+      title: 'Updated title',
+      severity: 'high',
+    });
+    expect(db.prepare('SELECT COUNT(*) count FROM finding_events').get()).toEqual({ count: 2 });
+    expect(db.prepare('SELECT COUNT(*) count FROM observation_findings').get()).toEqual({
+      count: 2,
+    });
+  });
+
+  it('Findingの反映に失敗した場合はObservation、Graph、Findingを残さない', () => {
+    const repo = new ObservationRepository(db);
+    expect(() =>
+      repo.record({
+        artifactId,
+        actor: 'worker-1',
+        content: {},
+        nodes: [
+          {
+            ref: 'host',
+            kind: 'host',
+            props: { authorityKind: 'IP', authority: '10.0.0.4' },
+          },
+        ],
+        findings: [
+          {
+            canonicalKey: 'valid-before-failure',
+            title: 'Would be valid',
+            severity: 'low',
+            confidence: 'medium',
+            nodeRef: 'host',
+          },
+          {
+            canonicalKey: 'invalid-node',
+            title: 'Invalid node ref',
+            severity: 'high',
+            confidence: 'high',
+            nodeRef: 'missing-node',
+          },
+        ],
+      }),
+    ).toThrow(/Finding node not found/);
+
+    expect(db.prepare('SELECT COUNT(*) count FROM observations').get()).toEqual({ count: 0 });
+    expect(db.prepare('SELECT COUNT(*) count FROM nodes').get()).toEqual({ count: 0 });
+    expect(db.prepare('SELECT COUNT(*) count FROM findings').get()).toEqual({ count: 0 });
+    expect(db.prepare('SELECT COUNT(*) count FROM finding_events').get()).toEqual({ count: 0 });
   });
 });

--- a/tests/mcp/tools/observations.test.ts
+++ b/tests/mcp/tools/observations.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { randomUUID } from 'node:crypto';
+import { migrateDatabase } from '../../../src/db/migrate.js';
+import { createMcpServer } from '../../../src/mcp/server.js';
+import { EngagementRepository } from '../../../src/db/repository/engagement-repository.js';
+
+describe('observe MCP tool', () => {
+  let db: InstanceType<typeof Database>;
+  let client: Client;
+  let artifactId: string;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    migrateDatabase(db);
+    const engagementId = new EngagementRepository(db).create({ name: 'test' }).id;
+    artifactId = randomUUID();
+    db.prepare(
+      `INSERT INTO artifacts (id, tool, kind, path, captured_at, engagement_id)
+       VALUES (?, 'worker', 'tool_output', '/tmp/result', ?, ?)`,
+    ).run(artifactId, new Date().toISOString(), engagementId);
+
+    const server = createMcpServer(db);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new Client({ name: 'test-client', version: '1.0.0' });
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    db.close();
+  });
+
+  it('Observation、Node、Findingを原子的に登録する', async () => {
+    const response = await client.callTool({
+      name: 'observe',
+      arguments: {
+        artifactId,
+        actor: 'worker-1',
+        contentJson: JSON.stringify({ summary: 'finding discovered' }),
+        nodesJson: JSON.stringify([
+          {
+            ref: 'host',
+            kind: 'host',
+            props: { authorityKind: 'IP', authority: '192.0.2.10' },
+          },
+        ]),
+        findingsJson: JSON.stringify([
+          {
+            canonicalKey: 'host-finding:192.0.2.10',
+            title: 'Host finding',
+            severity: 'high',
+            confidence: 'high',
+            nodeRef: 'host',
+          },
+        ]),
+      },
+    });
+
+    expect(response.isError).not.toBe(true);
+    const result = JSON.parse(
+      (response.content as Array<{ type: string; text: string }>)[0].text,
+    ) as { findingIds: string[] };
+    expect(result.findingIds).toHaveLength(1);
+    expect(db.prepare('SELECT COUNT(*) count FROM findings').get()).toEqual({ count: 1 });
+    expect(db.prepare('SELECT COUNT(*) count FROM observation_findings').get()).toEqual({
+      count: 1,
+    });
+  });
+});


### PR DESCRIPTION
## 変更内容

- observe入力へFindingの作成・更新定義を追加
- Observation、Node、Edge、Finding、関連表を一つのトランザクションで更新
- Finding Eventへ根拠Artifact IDを保存
- Node refをFindingのnode IDへ解決
- 途中失敗時の全ロールバックをテスト
- WikiのArchitecture、実装状況、Draftを更新

## 検証

- npm run format
- npm run lint
- npm run typecheck
- npm test（436 tests）
- npm run build

Closes #45