### PR TITLE
子Actionの提案と採用フローを追加

### DIFF
--- a/src/db/repository/action-queue-repository.ts
+++ b/src/db/repository/action-queue-repository.ts
@@ -282,6 +282,18 @@ export class ActionQueueRepository {
     return rowToActionQueueItem(row);
   }
 
+  adopt(id: string): ActionQueueItem | undefined {
+    const now = new Date().toISOString();
+    const result = this.db
+      .prepare(
+        `UPDATE action_queue
+         SET state = 'queued', available_at = ?, updated_at = ?
+         WHERE id = ? AND state = 'proposed'`,
+      )
+      .run(now, now, id);
+    return result.changes === 0 ? undefined : this.findById(id);
+  }
+
   /**
    * キューから次のアクションをポーリングする。
    *

--- a/src/db/repository/target-validator.ts
+++ b/src/db/repository/target-validator.ts
@@ -31,6 +31,18 @@ export class TargetValidator {
     }
   }
 
+  validateWithin(parentTargets: TargetRef[], childTargets: TargetRef[]): void {
+    if (parentTargets.length === 0) return;
+    for (const child of childTargets) {
+      const allowed = parentTargets.some((parent) => {
+        if (parent.type !== child.type) return false;
+        if (parent.id === child.id) return true;
+        return parent.type === 'node' && this.isReachableFrom(child.id, [parent.id]);
+      });
+      if (!allowed) throw new Error(`Child target is outside parent action scope: ${child.id}`);
+    }
+  }
+
   private validateNode(id: string, nodeIds?: string[], hostAuthorities?: string[]): void {
     const node = this.db.prepare('SELECT id, kind, props_json FROM nodes WHERE id = ?').get(id) as
       | { id: string; kind: string; props_json: string }

--- a/src/db/repository/worker-lifecycle-repository.ts
+++ b/src/db/repository/worker-lifecycle-repository.ts
@@ -8,6 +8,8 @@ import type {
   Artifact,
   RegisterArtifactInput,
 } from '../../types/operational.js';
+import { ActionParamsSchema } from '../../types/mission.js';
+import { TargetValidator } from './target-validator.js';
 
 export interface StartExecutionInput {
   actionId: string;
@@ -27,6 +29,16 @@ export interface FinishExecutionInput {
   errorMessage?: string;
   stdoutArtifactId?: string;
   stderrArtifactId?: string;
+}
+
+export interface ProposeChildActionInput {
+  executionId: string;
+  leaseOwner: string;
+  kind: string;
+  dedupeKey: string;
+  paramsJson?: string;
+  priority?: number;
+  maxAttempts?: number;
 }
 
 export class WorkerLifecycleRepository {
@@ -106,6 +118,33 @@ export class WorkerLifecycleRepository {
       sensitivity: input.sensitivity,
       attrsJson: input.attrsJson,
       contentBase64: input.contentBase64,
+    });
+  }
+
+  proposeChildAction(input: ProposeChildActionInput): ActionQueueItem {
+    const execution = this.requireActiveExecution(input.executionId, input.leaseOwner);
+    const parent = this.actions.findById(execution.actionId)!;
+    const parentParams = ActionParamsSchema.parse(JSON.parse(parent.paramsJson));
+    const parsedChildParams = ActionParamsSchema.parse(JSON.parse(input.paramsJson ?? '{}'));
+    const childParams =
+      parentParams.targets !== undefined && (parsedChildParams.targets?.length ?? 0) === 0
+        ? { ...parsedChildParams, targets: parentParams.targets }
+        : parsedChildParams;
+    new TargetValidator(this.db).validateWithin(
+      parentParams.targets ?? [],
+      childParams.targets ?? [],
+    );
+    return this.actions.enqueue({
+      engagementId: parent.engagementId,
+      missionId: parent.missionId,
+      runId: parent.runId,
+      parentActionId: parent.id,
+      kind: input.kind,
+      dedupeKey: input.dedupeKey,
+      paramsJson: JSON.stringify(childParams),
+      priority: input.priority,
+      maxAttempts: input.maxAttempts,
+      state: 'proposed',
     });
   }
 

--- a/src/mcp/tools/ops.ts
+++ b/src/mcp/tools/ops.ts
@@ -6,7 +6,7 @@
  *
  * Actions: create_engagement, list_engagements, get_engagement,
  *   update_engagement, delete_engagement, create_run, list_runs,
- *   get_run, update_run_status, enqueue_action, poll_action,
+ *   get_run, update_run_status, enqueue_action, adopt_action, poll_action,
  *   complete_action, fail_action, cancel_action, list_actions,
  *   get_execution, list_executions
  */
@@ -27,7 +27,7 @@ export function registerOpsTools(server: McpServer, db: Database.Database): void
 
   server.tool(
     'ops',
-    'Manage operational entities. Actions: create_engagement, list_engagements, get_engagement, update_engagement, delete_engagement, create_run, list_runs, get_run, update_run_status, enqueue_action, poll_action, complete_action, fail_action, cancel_action, list_actions, get_execution, list_executions',
+    'Manage operational entities. Actions: create_engagement, list_engagements, get_engagement, update_engagement, delete_engagement, create_run, list_runs, get_run, update_run_status, enqueue_action, adopt_action, poll_action, complete_action, fail_action, cancel_action, list_actions, get_execution, list_executions',
     {
       action: z.enum([
         'create_engagement',
@@ -40,6 +40,7 @@ export function registerOpsTools(server: McpServer, db: Database.Database): void
         'get_run',
         'update_run_status',
         'enqueue_action',
+        'adopt_action',
         'poll_action',
         'complete_action',
         'fail_action',
@@ -357,6 +358,25 @@ export function registerOpsTools(server: McpServer, db: Database.Database): void
               };
             }
             return { content: [{ type: 'text', text: JSON.stringify(polled, null, 2) }] };
+          }
+
+          case 'adopt_action': {
+            if (!id) {
+              return {
+                content: [{ type: 'text', text: 'id parameter is required for adopt_action' }],
+                isError: true,
+              };
+            }
+            const adopted = actionQueueRepo.adopt(id);
+            if (!adopted) {
+              return {
+                content: [
+                  { type: 'text', text: `Action not found or not in proposed state: ${id}` },
+                ],
+                isError: true,
+              };
+            }
+            return { content: [{ type: 'text', text: JSON.stringify(adopted, null, 2) }] };
           }
 
           case 'complete_action': {

--- a/src/mcp/tools/worker.ts
+++ b/src/mcp/tools/worker.ts
@@ -11,7 +11,13 @@ export function registerWorkerTool(server: McpServer, db: Database.Database): vo
     'worker',
     'Record Worker execution and artifacts for a leased Action',
     {
-      action: z.enum(['start_execution', 'register_artifact', 'finish_execution', 'renew_lease']),
+      action: z.enum([
+        'start_execution',
+        'register_artifact',
+        'propose_child_action',
+        'finish_execution',
+        'renew_lease',
+      ]),
       actionId: z.string().optional(),
       executionId: z.string().optional(),
       leaseOwner: z.string(),
@@ -32,6 +38,10 @@ export function registerWorkerTool(server: McpServer, db: Database.Database): vo
       sensitivity: z.string().optional(),
       attrsJson: z.string().optional(),
       contentBase64: z.string().optional(),
+      dedupeKey: z.string().optional(),
+      paramsJson: z.string().optional(),
+      priority: z.number().int().optional(),
+      maxAttempts: z.number().int().positive().optional(),
     },
     async (input) => {
       try {
@@ -55,6 +65,21 @@ export function registerWorkerTool(server: McpServer, db: Database.Database): vo
           return { content: [{ type: 'text', text: JSON.stringify(execution, null, 2) }] };
         }
         if (!input.executionId) throw new Error('executionId is required');
+        if (input.action === 'propose_child_action') {
+          if (!input.kind || !input.dedupeKey) {
+            throw new Error('kind and dedupeKey are required for propose_child_action');
+          }
+          const child = lifecycle.proposeChildAction({
+            executionId: input.executionId,
+            leaseOwner: input.leaseOwner,
+            kind: input.kind,
+            dedupeKey: input.dedupeKey,
+            paramsJson: input.paramsJson,
+            priority: input.priority,
+            maxAttempts: input.maxAttempts,
+          });
+          return { content: [{ type: 'text', text: JSON.stringify(child, null, 2) }] };
+        }
         if (input.action === 'register_artifact') {
           if (!input.kind || !input.path) {
             throw new Error('kind and path are required for register_artifact');

--- a/tests/db/repository/action-queue-repository.test.ts
+++ b/tests/db/repository/action-queue-repository.test.ts
@@ -396,6 +396,26 @@ describe('ActionQueueRepository', () => {
     });
   });
 
+  describe('adopt()', () => {
+    it('proposed Actionだけをqueuedへ遷移させる', () => {
+      const proposed = repo.enqueue({
+        engagementId,
+        kind: 'http_service_review',
+        dedupeKey: 'proposal:adopt',
+        state: 'proposed',
+      });
+      const queued = repo.enqueue({
+        engagementId,
+        kind: 'http_service_review',
+        dedupeKey: 'proposal:already-queued',
+      });
+
+      expect(repo.poll('worker-1', 300, ['http_service_review'])?.id).toBe(queued.id);
+      expect(repo.adopt(proposed.id)?.state).toBe('queued');
+      expect(repo.adopt(queued.id)).toBeUndefined();
+    });
+  });
+
   // =======================================================================
   // cancel()
   // =======================================================================

--- a/tests/db/repository/worker-lifecycle-repository.test.ts
+++ b/tests/db/repository/worker-lifecycle-repository.test.ts
@@ -8,6 +8,7 @@ import { EngagementRepository } from '../../../src/db/repository/engagement-repo
 import { MissionRepository } from '../../../src/db/repository/mission-repository.js';
 import { ActionQueueRepository } from '../../../src/db/repository/action-queue-repository.js';
 import { WorkerLifecycleRepository } from '../../../src/db/repository/worker-lifecycle-repository.js';
+import { NodeRepository } from '../../../src/db/repository/node-repository.js';
 
 describe('WorkerLifecycleRepository', () => {
   let db: InstanceType<typeof Database>;
@@ -16,6 +17,8 @@ describe('WorkerLifecycleRepository', () => {
   let actionId: string;
   let missionId: string;
   let artifactRoot: string;
+  let parentTargetId: string;
+  let outsideParentTargetId: string;
 
   beforeEach(() => {
     db = new Database(':memory:');
@@ -27,12 +30,22 @@ describe('WorkerLifecycleRepository', () => {
       objective: 'Webの攻撃面を調査する',
     });
     missionId = mission.id;
+    const nodes = new NodeRepository(db);
+    parentTargetId = nodes.upsert('host', {
+      authorityKind: 'IP',
+      authority: '192.0.2.1',
+    }).node.id;
+    outsideParentTargetId = nodes.upsert('host', {
+      authorityKind: 'IP',
+      authority: '192.0.2.2',
+    }).node.id;
     actions = new ActionQueueRepository(db);
     const action = actions.enqueue({
       engagementId: engagement.id,
       missionId,
       kind: 'web_endpoint_discovery',
       dedupeKey: 'web:test',
+      paramsJson: JSON.stringify({ targets: [{ type: 'node', id: parentTargetId }] }),
     });
     actionId = action.id;
     actions.poll('worker-1');
@@ -75,6 +88,66 @@ describe('WorkerLifecycleRepository', () => {
         executor: 'worker-2',
       }),
     ).toThrow(/lease owner/);
+  });
+
+  it('子Actionをproposedで登録し親のMissionを継承する', () => {
+    const execution = lifecycle.startExecution({
+      actionId,
+      leaseOwner: 'worker-1',
+      executor: 'worker-1',
+    });
+
+    const child = lifecycle.proposeChildAction({
+      executionId: execution.id,
+      leaseOwner: 'worker-1',
+      kind: 'http_service_review',
+      dedupeKey: 'child:review',
+    });
+
+    expect(child.state).toBe('proposed');
+    expect(child.parentActionId).toBe(actionId);
+    expect(child.missionId).toBe(missionId);
+    expect(JSON.parse(child.paramsJson)).toMatchObject({
+      targets: [{ type: 'node', id: parentTargetId }],
+    });
+    expect(actions.poll('worker-2', 300, ['http_service_review'])).toBeUndefined();
+  });
+
+  it('別Workerは子Actionを提案できない', () => {
+    const execution = lifecycle.startExecution({
+      actionId,
+      leaseOwner: 'worker-1',
+      executor: 'worker-1',
+    });
+
+    expect(() =>
+      lifecycle.proposeChildAction({
+        executionId: execution.id,
+        leaseOwner: 'worker-2',
+        kind: 'http_service_review',
+        dedupeKey: 'child:invalid-worker',
+      }),
+    ).toThrow(/lease owner/);
+  });
+
+  it('親Actionの対象範囲外にある子Actionを拒否する', () => {
+    const execution = lifecycle.startExecution({
+      actionId,
+      leaseOwner: 'worker-1',
+      executor: 'worker-1',
+    });
+
+    expect(() =>
+      lifecycle.proposeChildAction({
+        executionId: execution.id,
+        leaseOwner: 'worker-1',
+        kind: 'http_service_review',
+        dedupeKey: 'child:outside-parent',
+        paramsJson: JSON.stringify({
+          targets: [{ type: 'node', id: outsideParentTargetId }],
+        }),
+      }),
+    ).toThrow(/outside parent action scope/);
   });
 
   it('期限切れleaseではExecutionを開始できない', () => {

--- a/tests/mcp/tools/ops.test.ts
+++ b/tests/mcp/tools/ops.test.ts
@@ -373,6 +373,39 @@ describe('MCP Ops Tool', () => {
       expect(getText(result)).toContain('No action available');
     });
 
+    it('adopt_action — proposed Actionを実行可能にする', async () => {
+      const enqueueResult = await callOps({
+        action: 'enqueue_action',
+        engagementId,
+        kind: 'http_service_review',
+        dedupeKey: 'proposal:mcp-adopt',
+        state: 'proposed',
+      });
+      const proposal = parseResult<{ id: string; state: string }>(enqueueResult);
+      expect(proposal.state).toBe('proposed');
+
+      const before = await callOps({
+        action: 'poll_action',
+        leaseOwner: 'worker-1',
+        acceptedKinds: ['http_service_review'],
+      });
+      expect(getText(before)).toContain('No action available');
+
+      const adopted = parseResult<{ state: string }>(
+        await callOps({ action: 'adopt_action', id: proposal.id }),
+      );
+      expect(adopted.state).toBe('queued');
+
+      const after = parseResult<{ id: string }>(
+        await callOps({
+          action: 'poll_action',
+          leaseOwner: 'worker-1',
+          acceptedKinds: ['http_service_review'],
+        }),
+      );
+      expect(after.id).toBe(proposal.id);
+    });
+
     it('poll_action — leaseOwner 未指定でエラー', async () => {
       const result = await callOps({ action: 'poll_action' });
       expect(result.isError).toBe(true);

--- a/tests/mcp/tools/worker.test.ts
+++ b/tests/mcp/tools/worker.test.ts
@@ -95,4 +95,36 @@ describe('worker MCP tool', () => {
     ) as { action: { state: string } };
     expect(result.action.state).toBe('succeeded');
   });
+
+  it('子Actionを実行待ちへ入れずに提案する', async () => {
+    const started = await client.callTool({
+      name: 'worker',
+      arguments: {
+        action: 'start_execution',
+        actionId,
+        leaseOwner: 'worker-1',
+        executor: 'worker-1',
+      },
+    });
+    const execution = JSON.parse(
+      (started.content as Array<{ type: string; text: string }>)[0].text,
+    ) as { id: string };
+
+    const proposed = await client.callTool({
+      name: 'worker',
+      arguments: {
+        action: 'propose_child_action',
+        executionId: execution.id,
+        leaseOwner: 'worker-1',
+        kind: 'http_service_review',
+        dedupeKey: 'child:mcp-proposal',
+      },
+    });
+    expect(proposed.isError).not.toBe(true);
+    const child = JSON.parse(
+      (proposed.content as Array<{ type: string; text: string }>)[0].text,
+    ) as { state: string; parentActionId: string };
+    expect(child.state).toBe('proposed');
+    expect(child.parentActionId).toBe(actionId);
+  });
 });


### PR DESCRIPTION
## 変更内容

- Workerがlease中のExecutionから子Actionをproposed状態で登録
- 子Actionへ親のEngagement、Mission、Run、対象範囲を継承
- 明示した子対象が親Actionの範囲外なら拒否
- proposed Actionをpoll_actionの対象外に維持
- 戦術管制向けadopt_actionでqueuedへ遷移
- Wikiを現行仕様へ更新

## 検証

- npm run format
- npm run lint
- npm run typecheck
- npm test（442 tests）
- npm run build

Closes #50